### PR TITLE
[ONLY MERGE WHEN RELEASING 0.18] Revert "Spaceflights - Update requirements and catalog so that openpyxl is taken over outdated xlrd"

### DIFF
--- a/spaceflights/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/spaceflights/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -55,8 +55,6 @@ shuttles:
   type: pandas.ExcelDataSet
   filepath: data/01_raw/shuttles.xlsx
   layer: raw
-  load_args:
-    engine: openpyxl
 
 preprocessed_companies:
   type: pandas.CSVDataSet

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -6,7 +6,6 @@ jupyter~=1.0
 jupyter_client>=5.1, <7.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet,pandas.ExcelDataSet]=={{ cookiecutter.kedro_version }}
-openpyxl>=3.0.6, <4.0
 kedro-telemetry~=0.1.0
 kedro-viz==3.16.0; python_version=='3.6'
 kedro-viz~=4.0; python_version>'3.6'


### PR DESCRIPTION
Reverts quantumblacklabs/kedro-starters#49. In kedro 0.18 , `openpyxl` is the default and will be installed through `kedro[pandas.ExcelDataSet]`.