### PR TITLE
fix: correct parameter subset to input of split node

### DIFF
--- a/spaceflights/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_science/pipeline.py
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_science/pipeline.py
@@ -9,7 +9,7 @@ def create_pipeline(**kwargs) -> Pipeline:
         [
             node(
                 func=split_data,
-                inputs=["model_input_table", "parameters"],
+                inputs=["model_input_table", "params:model_options"],
                 outputs=["X_train", "X_test", "y_train", "y_test"],
                 name="split_data_node",
             ),


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->

#58 misses a change on the parameter passed to the split node function. This PR corrects it to use the subset from params. 

Note: The latest docs have it right.


## How has this been tested?
<!-- What testing strategies have you used? -->

Running `kedro run` on the project created from the starter locally.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

