### PR TITLE
Update black to non pre-release version

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==21.5b1
+black==22.1.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
@@ -15,7 +15,9 @@ from kedro.framework.context import KedroContext
 
 @pytest.fixture
 def project_context():
-    return KedroContext(package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd())
+    return KedroContext(
+        package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd()
+    )
 
 
 # The tests below are here for the demonstration purpose

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==21.5b1
+black==22.1.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
@@ -15,7 +15,9 @@ from kedro.framework.context import KedroContext
 
 @pytest.fixture
 def project_context():
-    return KedroContext(package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd())
+    return KedroContext(
+        package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd()
+    )
 
 
 # The tests below are here for the demonstration purpose

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==21.5b1
+black==22.1.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
@@ -15,7 +15,9 @@ from kedro.framework.context import KedroContext
 
 @pytest.fixture
 def project_context():
-    return KedroContext(package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd())
+    return KedroContext(
+        package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd()
+    )
 
 
 # The tests below are here for the demonstration purpose

--- a/pyspark/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==21.5b1
+black==22.1.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pyspark/{{ cookiecutter.repo_name }}/src/tests/test_run.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/tests/test_run.py
@@ -15,7 +15,9 @@ from kedro.framework.context import KedroContext
 
 @pytest.fixture
 def project_context():
-    return KedroContext(package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd())
+    return KedroContext(
+        package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd()
+    )
 
 
 # The tests below are here for the demonstration purpose

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==21.5b1
+black==22.1.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/tests/test_run.py
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/tests/test_run.py
@@ -15,7 +15,9 @@ from kedro.framework.context import KedroContext
 
 @pytest.fixture
 def project_context():
-    return KedroContext(package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd())
+    return KedroContext(
+        package_name="{{ cookiecutter.python_package }}", project_path=Path.cwd()
+    )
 
 
 # The tests below are here for the demonstration purpose

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 bandit>=1.6.2, <2.0; python_version > '3.6'
 bandit>=1.6.2, <1.7.2; python_version == '3.6'
 behave>=1.2.6, <2.0
-black==21.5b1
+black==22.1.0
 click<8.0
 isort~=5.0
 PyYAML>=4.2, <6.0


### PR DESCRIPTION
## Motivation and Context

Upgrade black to 22.1.0 consistently with https://github.com/kedro-org/kedro/issues/1327.

## How has this been tested?

- I have run black on the entire repo. Notice that some files return an error because of the jinja tags which are not valid python.
-  I also manually created a project fom each starter and run black and one single file is sometimes modified: the ``setup.py`` because the length of line with the entry point depends on the length of the project, which we don't know in advance. There are not other modifcation.
- As for the original repo, I did NOT change black version in ``test_requirements.txt``. Should I?
## Checklist

- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR -> *I don't have the right to do it*
- [ ] Added tests to cover my changes *-> should I create a test to check if the template is "black valid"? What should I do for the lines which are splitted depending on the length of the project name?*

