### PR TITLE
Fix `kedro new` default python package name in starters

### DIFF
--- a/astro-airflow-iris/cookiecutter.json
+++ b/astro-airflow-iris/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }

--- a/pandas-iris/cookiecutter.json
+++ b/pandas-iris/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }

--- a/pyspark-iris/cookiecutter.json
+++ b/pyspark-iris/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }

--- a/pyspark/cookiecutter.json
+++ b/pyspark/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }

--- a/spaceflights/cookiecutter.json
+++ b/spaceflights/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }


### PR DESCRIPTION
## Motivation and Context
Related to https://github.com/kedro-org/kedro/pull/1362

## How has this been tested?
<!-- What testing strategies have you used? -->
Manually test with the following command
`kedro new --starter=spaceflights --checkout fix/fix-kedro-new-default-package-name`

![image](https://user-images.githubusercontent.com/18221871/159756554-afddba22-70ae-427c-a4c5-83fc333eeb74.png)

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

