### PR TITLE
Make `black` requirement consistent with core Kedro & remove `click` requirement

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black>=22.3.0
+black~=22.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black>=22.3.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black>=22.3.0
+black~=22.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black>=22.3.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black>=22.3.0
+black~=22.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black>=22.3.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pyspark/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black>=22.3.0
+black~=22.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/pyspark/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black>=22.3.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black>=22.3.0
+black~=22.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black>=22.3.0
 flake8>=3.7.9, <4.0
 ipython>=7.31.1, <8.0
 isort~=5.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,4 @@
-bandit>=1.6.2, <2.0; python_version > '3.6'
-bandit>=1.6.2, <1.7.2; python_version == '3.6'
+bandit>=1.6.2, <2.0
 behave>=1.2.6, <2.0
 black~=22.0
 isort~=5.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 bandit>=1.6.2, <2.0; python_version > '3.6'
 bandit>=1.6.2, <1.7.2; python_version == '3.6'
 behave>=1.2.6, <2.0
-black==22.1.0
+black>=22.3.0
 click<8.0
 isort~=5.0
 PyYAML>=4.2, <6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 bandit>=1.6.2, <2.0; python_version > '3.6'
 bandit>=1.6.2, <1.7.2; python_version == '3.6'
 behave>=1.2.6, <2.0
-black>=22.3.0
+black~=22.0
 click<8.0
 isort~=5.0
 PyYAML>=4.2, <6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,6 @@ bandit>=1.6.2, <2.0; python_version > '3.6'
 bandit>=1.6.2, <1.7.2; python_version == '3.6'
 behave>=1.2.6, <2.0
 black~=22.0
-click<9.0
 isort~=5.0
 PyYAML>=4.2, <6.0
 git+https://github.com/kedro-org/kedro.git@develop#egg=kedro

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ bandit>=1.6.2, <2.0; python_version > '3.6'
 bandit>=1.6.2, <1.7.2; python_version == '3.6'
 behave>=1.2.6, <2.0
 black~=22.0
-click<8.0
+click<9.0
 isort~=5.0
 PyYAML>=4.2, <6.0
 git+https://github.com/kedro-org/kedro.git@develop#egg=kedro


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Motivation and Context
The latest click 8.1.0 is incompatible with black versions < 22.3.0

https://github.com/pallets/click/issues/2232
https://github.com/psf/black/issues/2964

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

