### PR TITLE
Fix merge mistake in test in pandas-iris starter

### DIFF
--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/tests/test_run.py
@@ -22,14 +22,13 @@ def config_loader():
 
 
 @pytest.fixture
-def project_context():
-    def project_context(config_loader):
-        return KedroContext(
-            package_name="{{ cookiecutter.python_package }}",
-            project_path=Path.cwd(),
-            config_loader=config_loader,
-            hook_manager=_create_hook_manager(),
-        )
+def project_context(config_loader):
+    return KedroContext(
+        package_name="{{ cookiecutter.python_package }}",
+        project_path=Path.cwd(),
+        config_loader=config_loader,
+        hook_manager=_create_hook_manager(),
+    )
 
 
 # The tests below are here for the demonstration purpose


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Motivation and Context
I'm not entirely sure why this test didn't fail when the merge error happened, but it's now causing failures in the `kedro-docker` build: https://github.com/kedro-org/kedro-plugins/pull/28

## How has this been tested?


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

