### PR TITLE
Update spaceflights kedro-viz requirement

### DIFF
--- a/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -6,7 +6,7 @@ jupyter~=1.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet, pandas.ExcelDataSet, pandas.ParquetDataSet]=={{ cookiecutter.kedro_version }}
 kedro-telemetry~=0.2.0
-kedro-viz~=4.0; python_version < '3.9'
+kedro-viz~=4.0
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0


### PR DESCRIPTION
Now that kedro-viz supports all the same versions of Python as kedro does, we should remove the version specifier.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

