### PR TITLE
Fix standalone-datacatlog ConfigLoader

### DIFF
--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/Example Notebook.ipynb
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/Example Notebook.ipynb
@@ -38,7 +38,7 @@
     "from kedro.io import DataCatalog\n",
     "\n",
     "# Initialise a ConfigLoader\n",
-    "conf_loader = ConfigLoader(\"conf/base\")\n",
+    "conf_loader = ConfigLoader(\"conf\")\n",
     "\n",
     "# Load the data catalog configuration from catalog.yml\n",
     "conf_catalog = conf_loader.get(\"catalog.yml\")\n",

--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
@@ -1,4 +1,4 @@
-## Overview
+# Overview
 
 This is a bare minimum setup for you to use a core component of Kedro in the exploratory phase of a project. Specifically, it enables you to use Kedro to configure and explore data sources in Jupyter notebook through the [DataCatalog](https://kedro.readthedocs.io/en/stable/data/data_catalog.html) feature.
 Later on, you can build a full pipeline using the same configuration.

--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
@@ -1,4 +1,4 @@
-# Overview
+## Overview
 
 This is a bare minimum setup for you to use a core component of Kedro in the exploratory phase of a project. Specifically, it enables you to use Kedro to configure and explore data sources in Jupyter notebook through the [DataCatalog](https://kedro.readthedocs.io/en/stable/data/data_catalog.html) feature.
 Later on, you can build a full pipeline using the same configuration.


### PR DESCRIPTION
## Motivation and Context
Closes https://github.com/kedro-org/kedro-starters/issues/86. `ConfigLoader` arguments changed in 0.18 but we forgot to update the standalone data catalog example.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

