### PR TITLE
Pyspark-iris Windows CI fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,6 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx /m PATH %PATH%;"C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,40 @@ commands:
           command: |
             conda activate kedro-starters
             pip freeze
+      - run:
+          # Required for Tensorflow tests
+          name: Install Microsoft Visual C++ Redistributable
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://aka.ms/vs/16/release/vc_redist.x64.exe -OutFile vc_redist.x64.exe
+            .\vc_redist.x64.exe /S /v/qn
+            - run:
+                name: Install Java 8
+                command: |
+                  $ProgressPreference = "SilentlyContinue"
+                  Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
+                  Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
+            - run:
+                name: Create Inbound rules for Java
+                command: |
+                  New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+                  New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+            - run:
+                name: Set Java environment variables
+                command: |
+                  [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
+                  setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
+            - run:
+                name: Setup Hadoop binary
+                command: |
+                  $ProgressPreference = "SilentlyContinue"
+                  Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
+                  New-Item -ItemType directory -Path C:\hadoop\bin
+                  mv .\winutils.exe C:\hadoop\bin
+                  setx /m HADOOP_HOME "C:\hadoop\"
+            - run:
+                name: Install 'make' command
+                command: choco install make
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,27 +104,11 @@ commands:
             pip freeze
       - run:
           # Required for Tensorflow tests
-          name: Install Microsoft Visual C++ Redistributable
+          name: Install OpenJDK
           command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://aka.ms/vs/16/release/vc_redist.x64.exe -OutFile vc_redist.x64.exe
-            .\vc_redist.x64.exe /S /v/qn
-      - run:
-          name: Install Java 8
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
-            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
-      - run:
-          name: Create Inbound rules for Java
-          command: |
-            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-      - run:
-          name: Set Java environment variables
-          command: |
-            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
-            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
+            choco install openjdk --version=11.0
+            echo $JAVA_HOME
+            java -version
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ commands:
             Move-Item .\winutils.exe C:\hadoop\bin
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx /M PATH "%PATH%;C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,10 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
+            Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            pathman /au "C:\hadoop\bin"
+            setx /m path "%path%;C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,27 @@ commands:
       - run:
           name: Install Java 8
           command: |
-            choco install openjdk
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jdk_x64_windows_11.0.16_8.zip -OutFile OpenJDK8U.zip
+            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
+      - run:
+          name: Create Inbound rules for Java
+          command: |
+            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-11.0.16_8\bin\java.exe" -Action Allow
+            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-11.0.16_8\bin\java.exe" -Action Allow
+      - run:
+          name: Set Java environment variables
+          command: |
+            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-11.0.16_8\bin", "Machine")
+            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-11.0.16_8"
+      - run:
+          name: Setup Hadoop binary
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/cdarlint/winutils/tree/master/hadoop-3.2.2/bin/winutils.exe -OutFile winutils.exe
+            New-Item -ItemType directory -Path C:\hadoop\bin
+            mv .\winutils.exe C:\hadoop\bin
+            setx /m HADOOP_HOME "C:\hadoop\"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,14 +105,8 @@ commands:
       - run:
           name: Setup Hadoop binary
           command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/winutils.exe?raw=true -OutFile winutils.exe
-            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/hadoop.dll?raw=true -OutFile hadoop.dll
-            New-Item -ItemType directory -Path C:\hadoop\bin
-            Move-Item .\winutils.exe C:\hadoop\bin
-            Copy-Item .\hadoop.dll C:\Windows\System32
-            Move-Item .\hadoop.dll C:\hadoop\bin
-            setx /m HADOOP_HOME "C:\hadoop"
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.6.3/bin/hadoop.dll?raw=true -OutFile hadoop.dll
+            Move-Item .\hadoop.dll C:\Windows\System32
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,9 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
-            Move-Item .\hadoop.dll C:\hadoop\bin
+            Copy-Item .\hadoop.dll C:\Windows\System32
             setx /m HADOOP_HOME "C:\hadoop\"
+            setx /M PATH "$env:path%;C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx /m PATH=%PATH%;"C:\hadoop\bin"
+            setx /m PATH %PATH%;"C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,6 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
-      - win_setup_env:
       - win_setup_requirements:
           python_version: <<parameters.python_version>>
       - win_e2e_run
@@ -217,7 +216,6 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
-      - win_setup_env:
       - win_setup_requirements:
           python_version: <<parameters.python_version>>
       - win_e2e_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/cdarlint/winutils/tree/master/hadoop-2.6.1/bin/winutils.exe -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/winutils.exe -OutFile winutils.exe
             New-Item -ItemType directory -Path C:\hadoop\bin
             mv .\winutils.exe C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx PATH=%PATH%;"C:\hadoop\bin"
+            setx /m PATH=%PATH%;"C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
+            set PATH=%PATH%;C:\hadoop\
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,24 +110,24 @@ commands:
           name: Install Java 8
           command: |
             $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jdk_x64_windows_11.0.16_8.zip -OutFile OpenJDK8U.zip
+            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
             Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
       - run:
           name: Create Inbound rules for Java
           command: |
-            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-11.0.16_8\bin\java.exe" -Action Allow
-            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-11.0.16_8\bin\java.exe" -Action Allow
+            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
       - run:
           name: Set Java environment variables
           command: |
-            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-11.0.16_8\bin", "Machine")
-            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-11.0.16_8"
+            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
+            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
       - run:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-            Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/hadoop.dll -OutFile hadoop.dll
+            Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.3/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
             Copy-Item .\hadoop.dll C:\Windows\System32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
           # Required for Tensorflow tests
           name: Install OpenJDK
           command: |
-            choco install openjdk --version=11.0 --allow-downgrade
+            choco install openjdk
             echo $JAVA_HOME
             java -version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,14 +126,6 @@ commands:
             [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
             setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
       - run:
-          name: Setup Hadoop binary
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-            New-Item -ItemType directory -Path C:\hadoop\bin
-            mv .\winutils.exe C:\hadoop\bin
-            setx /m HADOOP_HOME "C:\hadoop\"
-      - run:
           name: Install 'make' command
           command: choco install make
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,6 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
             Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
-            copy .\hadoop.dll C:\Windows\System32
             mv .\winutils.exe C:\hadoop\bin
             mv .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
             Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
-            cp .\hadoop.dll C:\Windows\System32
+            copy .\hadoop.dll C:\Windows\System32
             mv .\winutils.exe C:\hadoop\bin
             mv .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
           # Required for Tensorflow tests
           name: Install OpenJDK
           command: |
-            choco install openjdk
+            choco install openjdk --version=11.0.16 --allow-downgrade
             echo $JAVA_HOME
             java -version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ commands:
       - run:
           name: Install Java 8
           command: |
-            choco install openjdk --version=11.0
+            choco install openjdk
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,22 @@ commands:
           command: |
             conda activate kedro-starters
             pip freeze
+      - run:
+          name: Install Java 8
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
+            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
+      - run:
+          name: Create Inbound rules for Java
+          command: |
+            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+      - run:
+          name: Set Java environment variables
+          command: |
+            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
+            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/cdarlint/winutils/tree/master/hadoop-3.2.2/bin/winutils.exe -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/cdarlint/winutils/tree/master/hadoop-2.7.7/bin/winutils.exe -OutFile winutils.exe
             New-Item -ItemType directory -Path C:\hadoop\bin
             mv .\winutils.exe C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,9 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
-            Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
+            setx /M PATH "%PATH%;C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,9 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx /m path "%path%;C:\hadoop\bin"
+      - run:
+          name: Install 'make' command
+          command: choco install make
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,8 +131,11 @@ commands:
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
             Copy-Item .\hadoop.dll C:\Windows\System32
+            Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
             setx /M PATH "$env:path%;C:\hadoop"
+            echo $env:path
+            echo PATH
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,8 @@ commands:
       - run:
           name: Setup Hadoop binary
           command: |
-            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.6.3/bin/winutils.exe?raw=true -OutFile winutils.exe
-            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.6.3/bin/hadoop.dll?raw=true -OutFile hadoop.dll
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/winutils.exe?raw=true -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/hadoop.dll?raw=true -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
             Copy-Item .\hadoop.dll C:\Windows\System32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,12 @@ commands:
             $ProgressPreference = "SilentlyContinue"
             Invoke-WebRequest https://aka.ms/vs/16/release/vc_redist.x64.exe -OutFile vc_redist.x64.exe
             .\vc_redist.x64.exe /S /v/qn
-            - run:
-                name: Install Java 8
-                command: |
-                  $ProgressPreference = "SilentlyContinue"
-                  Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
-                  Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
+      - run:
+          name: Install Java 8
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
+            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
       - run:
           name: Create Inbound rules for Java
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,8 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.6.3/bin/hadoop.dll?raw=true -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
-            Move-Item .\hadoop.dll C:\Windows\System32
+            Copy-Item .\hadoop.dll C:\Windows\System32
+            Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop"
 
   win_e2e_run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
           command: |
             $ProgressPreference = "SilentlyContinue"
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-            Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.3/bin/hadoop.dll -OutFile hadoop.dll
+            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
             Copy-Item .\hadoop.dll C:\Windows\System32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ commands:
             mv .\winutils.exe C:\hadoop\bin
             mv .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx PATH=%PATH%;%HADOOP_HOME%/bin;
+            pathman /au %HADOOP_HOME%/bin;
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,11 @@ commands:
       - run:
           name: Setup Hadoop binary
           command: |
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/winutils.exe?raw=true -OutFile winutils.exe
             Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/hadoop.dll?raw=true -OutFile hadoop.dll
             Move-Item .\hadoop.dll C:\Windows\System32
+            New-Item -ItemType directory -Path C:\hadoop\bin
+            Move-Item .\winutils.exe C:\hadoop\bin
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,43 +82,6 @@ commands:
           name: Create 'kedro-starters' conda environment
           command: conda create --name kedro-starters python=<<parameters.python_version>> -y
 
-  win_setup_env:
-    steps:
-      - run:
-          # Required for Tensorflow tests
-          name: Install Microsoft Visual C++ Redistributable
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://aka.ms/vs/16/release/vc_redist.x64.exe -OutFile vc_redist.x64.exe
-            .\vc_redist.x64.exe /S /v/qn
-      - run:
-          name: Install Java 8
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
-            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
-      - run:
-          name: Create Inbound rules for Java
-          command: |
-            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-      - run:
-          name: Set Java environment variables
-          command: |
-            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
-            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
-      - run:
-          name: Setup Hadoop binary
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-            New-Item -ItemType directory -Path C:\hadoop\bin
-            mv .\winutils.exe C:\hadoop\bin
-            setx /m HADOOP_HOME "C:\hadoop\"
-      - run:
-          name: Install 'make' command
-          command: choco install make
-
   win_setup_requirements:
     parameters:
       python_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ commands:
             [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
             setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
             echo $JAVA_HOME
-            java -version
       - run:
           name: Setup Hadoop binary
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,28 +109,7 @@ commands:
       - run:
           name: Install Java 8
           command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
-            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
-      - run:
-          name: Create Inbound rules for Java
-          command: |
-            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-      - run:
-          name: Set Java environment variables
-          command: |
-            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
-            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
-            echo $JAVA_HOME
-      - run:
-          name: Setup Hadoop binary
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-            New-Item -ItemType directory -Path C:\hadoop\bin
-            mv .\winutils.exe C:\hadoop\bin
-            setx /m HADOOP_HOME "C:\hadoop\"
+            choco install openjdk --version=11.0
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,26 +82,15 @@ commands:
           name: Create 'kedro-starters' conda environment
           command: conda create --name kedro-starters python=<<parameters.python_version>> -y
 
-  win_setup_requirements:
-    parameters:
-      python_version:
-        type: string
+  win_setup_env:
     steps:
       - run:
-          name: Install pip setuptools
+          # Required for Tensorflow tests
+          name: Install Microsoft Visual C++ Redistributable
           command: |
-            conda activate kedro-starters
-            python -m pip install -U "pip>=21.2" "setuptools>=38.0" wheel
-      - run:
-          name: Install test requirements
-          command: |
-            conda activate kedro-starters
-            pip install -r test_requirements.txt
-      - run:
-          name: Pip freeze
-          command: |
-            conda activate kedro-starters
-            pip freeze
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://aka.ms/vs/16/release/vc_redist.x64.exe -OutFile vc_redist.x64.exe
+            .\vc_redist.x64.exe /S /v/qn
       - run:
           name: Install Java 8
           command: |
@@ -126,6 +115,30 @@ commands:
             New-Item -ItemType directory -Path C:\hadoop\bin
             mv .\winutils.exe C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
+      - run:
+          name: Install 'make' command
+          command: choco install make
+
+  win_setup_requirements:
+    parameters:
+      python_version:
+        type: string
+    steps:
+      - run:
+          name: Install pip setuptools
+          command: |
+            conda activate kedro-starters
+            python -m pip install -U "pip>=21.2" "setuptools>=38.0" wheel
+      - run:
+          name: Install test requirements
+          command: |
+            conda activate kedro-starters
+            pip install -r test_requirements.txt
+      - run:
+          name: Pip freeze
+          command: |
+            conda activate kedro-starters
+            pip freeze
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows
@@ -192,6 +205,7 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
+      - win_setup_env:
       - win_setup_requirements:
           python_version: <<parameters.python_version>>
       - win_e2e_run
@@ -206,6 +220,7 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
+      - win_setup_env:
       - win_setup_requirements:
           python_version: <<parameters.python_version>>
       - win_e2e_lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,9 +134,6 @@ commands:
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
             setx /m path "%path%;C:\hadoop\bin"
-      - run:
-          name: Install 'make' command
-          command: choco install make
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/winutils.exe -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
             New-Item -ItemType directory -Path C:\hadoop\bin
             mv .\winutils.exe C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            set PATH=%PATH%;C:\hadoop\
+            setx PATH=%PATH%;C:\hadoop\bin
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,10 +129,10 @@ commands:
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
             Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
-            mv .\winutils.exe C:\hadoop\bin
-            mv .\hadoop.dll C:\hadoop\bin
+            Move-Item .\winutils.exe C:\hadoop\bin
+            Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            pathman /au %HADOOP_HOME%/bin;
+            pathman /au "C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,6 @@ commands:
           name: Uninstall OpenJDK
           command: |
             choco uninstall openjdk -x
-            echo $JAVA_HOME
-            java -version
       - run:
           name: Install Java 8
           command: |
@@ -124,6 +122,8 @@ commands:
           command: |
             [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
             setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
+            echo $JAVA_HOME
+            java -version
       - run:
           name: Setup Hadoop binary
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,8 @@ commands:
       - run:
           name: Setup Hadoop binary
           command: |
-            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/winutils.exe?raw=true -OutFile winutils.exe
             Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/hadoop.dll?raw=true -OutFile hadoop.dll
-            New-Item -ItemType directory -Path C:\hadoop\bin
-            Move-Item .\winutils.exe C:\hadoop\bin
-            Copy-Item .\hadoop.dll C:\Windows\System32
-            Move-Item .\hadoop.dll C:\hadoop\bin
-            setx /m HADOOP_HOME "C:\hadoop"
+            Move-Item .\hadoop.dll C:\Windows\System32
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/cdarlint/winutils/tree/master/hadoop-2.7.7/bin/winutils.exe -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/cdarlint/winutils/tree/master/hadoop-2.6.1/bin/winutils.exe -OutFile winutils.exe
             New-Item -ItemType directory -Path C:\hadoop\bin
             mv .\winutils.exe C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ commands:
             mv .\winutils.exe C:\hadoop\bin
             mv .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
+            setx PATH=%PATH%;%HADOOP_HOME%/bin;
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
           # Required for Tensorflow tests
           name: Install OpenJDK
           command: |
-            choco install openjdk --version=11.0
+            choco install openjdk --version=11.0 --allow-downgrade
             echo $JAVA_HOME
             java -version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,14 @@ commands:
           command: |
             [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
             setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
+      - run:
+          name: Setup Hadoop binary
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
+            New-Item -ItemType directory -Path C:\hadoop\bin
+            mv .\winutils.exe C:\hadoop\bin
+            setx /m HADOOP_HOME "C:\hadoop\"
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,27 +115,27 @@ commands:
                   $ProgressPreference = "SilentlyContinue"
                   Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
                   Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
-            - run:
-                name: Create Inbound rules for Java
-                command: |
-                  New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-                  New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-            - run:
-                name: Set Java environment variables
-                command: |
-                  [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
-                  setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
-            - run:
-                name: Setup Hadoop binary
-                command: |
-                  $ProgressPreference = "SilentlyContinue"
-                  Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-                  New-Item -ItemType directory -Path C:\hadoop\bin
-                  mv .\winutils.exe C:\hadoop\bin
-                  setx /m HADOOP_HOME "C:\hadoop\"
-            - run:
-                name: Install 'make' command
-                command: choco install make
+      - run:
+          name: Create Inbound rules for Java
+          command: |
+            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+      - run:
+          name: Set Java environment variables
+          command: |
+            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
+            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
+      - run:
+          name: Setup Hadoop binary
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
+            New-Item -ItemType directory -Path C:\hadoop\bin
+            mv .\winutils.exe C:\hadoop\bin
+            setx /m HADOOP_HOME "C:\hadoop\"
+      - run:
+          name: Install 'make' command
+          command: choco install make
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ commands:
             Move-Item .\hadoop.dll C:\Windows\System32
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
+            setx /m HADOOP_HOME "C:\hadoop"
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,35 @@ commands:
             conda activate kedro-starters
             pip freeze
       - run:
-          # Required for Tensorflow tests
-          name: Install OpenJDK
+          name: Uninstall OpenJDK
           command: |
-            choco install openjdk --version=11.0.16 --allow-downgrade
+            choco uninstall openjdk -x
             echo $JAVA_HOME
             java -version
+      - run:
+          name: Install Java 8
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
+            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
+      - run:
+          name: Create Inbound rules for Java
+          command: |
+            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
+      - run:
+          name: Set Java environment variables
+          command: |
+            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
+            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
+      - run:
+          name: Setup Hadoop binary
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
+            New-Item -ItemType directory -Path C:\hadoop\bin
+            mv .\winutils.exe C:\hadoop\bin
+            setx /m HADOOP_HOME "C:\hadoop\"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,10 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx /M PATH "$env:path%;C:\hadoop"
+            $newPath = 'C:\hadoop\'
+            $oldPath = [Environment]::GetEnvironmentVariable('PATH', 'Machine');
+            [Environment]::SetEnvironmentVariable('PATH', "$newPath;$oldPath",'Machine');
             echo $env:path
-            echo PATH
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,14 +126,14 @@ commands:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
-            Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/hadoop.dll -OutFile hadoop.dll
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/winutils.exe?raw=true -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.7.1/bin/hadoop.dll?raw=true -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
             Move-Item .\winutils.exe C:\hadoop\bin
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
-            setx /m HADOOP_HOME "C:\hadoop\"
-            $newPath = 'C:\hadoop\'
+            setx /m HADOOP_HOME "C:\hadoop"
+            $newPath = 'C:\hadoop'
             $oldPath = [Environment]::GetEnvironmentVariable('PATH', 'Machine');
             [Environment]::SetEnvironmentVariable('PATH', "$newPath;$oldPath",'Machine');
             echo $env:path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,11 @@ commands:
           command: |
             $ProgressPreference = "SilentlyContinue"
             Invoke-WebRequest https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.3/bin/winutils.exe -OutFile winutils.exe
+            Invoke-WebRequest https://github.com/steveloughran/winutils/tree/master/hadoop-2.6.4/bin/hadoop.dll -OutFile hadoop.dll
             New-Item -ItemType directory -Path C:\hadoop\bin
+            cp .\hadoop.dll C:\Windows\System32
             mv .\winutils.exe C:\hadoop\bin
+            mv .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
       - run:
           name: Install 'make' command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,26 +103,6 @@ commands:
             conda activate kedro-starters
             pip freeze
       - run:
-          name: Uninstall OpenJDK
-          command: |
-            choco uninstall openjdk -x
-      - run:
-          name: Install Java 8
-          command: |
-            $ProgressPreference = "SilentlyContinue"
-            Invoke-WebRequest https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_windows_8u252b09.zip -OutFile OpenJDK8U.zip
-            Expand-Archive .\OpenJDK8U.zip -DestinationPath C:\OpenJDK8U
-      - run:
-          name: Create Inbound rules for Java
-          command: |
-            New-NetFirewallRule -DisplayName "Allow JDK UDP" -Profile "Public" -Protocol "UDP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-            New-NetFirewallRule -DisplayName "Allow JDK TCP" -Profile "Public" -Protocol "TCP" -Direction Inbound -Program "C:\OpenJDK8U\openjdk-8u252-b09\bin\java.exe" -Action Allow
-      - run:
-          name: Set Java environment variables
-          command: |
-            [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable('Path', 'Machine') + ";C:\OpenJDK8U\openjdk-8u252-b09\bin", "Machine")
-            setx /m JAVA_HOME "C:\OpenJDK8U\openjdk-8u252-b09"
-      - run:
           name: Setup Hadoop binary
           command: |
             $ProgressPreference = "SilentlyContinue"
@@ -133,13 +113,6 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop"
-            $newPath = 'C:\hadoop'
-            $oldPath = [Environment]::GetEnvironmentVariable('PATH', 'Machine');
-            [Environment]::SetEnvironmentVariable('PATH', "$newPath;$oldPath",'Machine');
-            echo $env:path
-      - run:
-          name: Install 'make' command
-          command: choco install make
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ commands:
             Copy-Item .\hadoop.dll C:\Windows\System32
             Move-Item .\hadoop.dll C:\hadoop\bin
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx PATH=%PATH%;C:\hadoop\bin
+            setx PATH=%PATH%;"C:\hadoop\bin"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ commands:
             Move-Item .\winutils.exe C:\hadoop\bin
             Copy-Item .\hadoop.dll C:\Windows\System32
             setx /m HADOOP_HOME "C:\hadoop\"
-            setx /M PATH "$env:path%;C:\hadoop\bin"
+            setx /M PATH "$env:path%;C:\hadoop"
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,12 @@ commands:
       - run:
           name: Setup Hadoop binary
           command: |
+            Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.6.3/bin/winutils.exe?raw=true -OutFile winutils.exe
             Invoke-WebRequest https://github.com/steveloughran/winutils/blob/master/hadoop-2.6.3/bin/hadoop.dll?raw=true -OutFile hadoop.dll
+            New-Item -ItemType directory -Path C:\hadoop\bin
+            Move-Item .\winutils.exe C:\hadoop\bin
             Move-Item .\hadoop.dll C:\Windows\System32
+            setx /m HADOOP_HOME "C:\hadoop"
 
   win_e2e_run:
     description: Run `kedro run` end to end tests for all starters on Windows

--- a/features/environment.py
+++ b/features/environment.py
@@ -33,12 +33,6 @@ def _create_tmp_dir() -> Path:
 
 def before_scenario(context, scenario):
     """Environment preparation before each test is run."""
-
-    # Skip pyspark-iris on Windows CI (for now)
-    if _PYSPARK_IRIS_TAG in scenario.tags and os.name != "posix":
-        scenario.skip("pyspark-iris is not set up for Windows CI")
-        return
-
     kedro_install_venv_dir = create_new_venv()
     context.venv_dir = kedro_install_venv_dir
 


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Motivation and Context
<!-- Why was this PR created? -->
Related issue: https://github.com/kedro-org/kedro-starters/issues/95

The windows run tests do not pass due to a problem with pyspark-iris. This PR will look to fix this issue.

Notes:

- PySpark needs hadoop binaries installed. 
- Using Hadoop 2.7.1 binaries as 2.6.3 (Used on the framework) resulted in errors. 
- JDK comes pre-installed with this windows orb therefore does not need to be added.
- `hadoop.dll` needs to be placed in `C:\windows\system32`.
- `HADOOP_HOME` environment variable needs to be set to 'C:\hadoop'.
- `winutils.exe` needs to be added to 'C:\hadoop'.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

