### PR TITLE
pin jinja2 for all starters

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/setup.py
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/setup.py
@@ -33,6 +33,7 @@ setup(
             "sphinx-autodoc-typehints==1.11.1",
             "sphinx_copybutton==0.3.1",
             "ipykernel>=5.3, <7.0",
+            "Jinja2<3.1.0",
         ]
     },
 )

--- a/pyspark/{{ cookiecutter.repo_name }}/src/setup.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/setup.py
@@ -33,6 +33,7 @@ setup(
             "sphinx-autodoc-typehints==1.11.1",
             "sphinx_copybutton==0.3.1",
             "ipykernel>=5.3, <7.0",
+            "Jinja2<3.1.0",
         ]
     },
 )

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/setup.py
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/setup.py
@@ -33,6 +33,7 @@ setup(
             "sphinx-autodoc-typehints==1.11.1",
             "sphinx_copybutton==0.3.1",
             "ipykernel>=5.3, <7.0",
+            "Jinja2<3.1.0",
         ]
     },
 )


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->
only the **pandas-iris** and **pyspark-iris** have pinned `jinja2`, this PR make sure all starters are pinned.


## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

