### PR TITLE
Fix pandas futurewarning

### DIFF
--- a/spaceflights/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_processing/nodes.py
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/data_processing/nodes.py
@@ -12,7 +12,7 @@ def _parse_percentage(x: pd.Series) -> pd.Series:
 
 
 def _parse_money(x: pd.Series) -> pd.Series:
-    x = x.str.replace("$", "").str.replace(",", "")
+    x = x.str.replace("$", "", regex=True).str.replace(",", "")
     x = x.astype(float)
     return x
 


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Motivation and Context
Resolve part of https://github.com/kedro-org/kedro/issues/2202

```
 WARNING  /Users/merel_theisen/Projects/Testing/deprecations-spaceflights/src/deprecations_spaceflights/pipelines/data_processing/nodes.py:15: FutureWarning: The default value of regex will change from   warnings.py:109
                             True to False in a future version. In addition, single character regular expressions will *not* be treated as literal strings when regex=True.
                               x = x.str.replace("$", "").str.replace(",", "")
```

Is resolved by adding `regex=True` to the first replace in `_parse_money()`


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

