### PR TITLE
remove a duplicate extension 'mathjax' from conf.py

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -49,7 +49,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",

--- a/pandas-iris/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -47,7 +47,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -47,7 +47,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",

--- a/pyspark/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -48,7 +48,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",

--- a/spaceflights/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/spaceflights/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -47,7 +47,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",


### PR DESCRIPTION
## Motivation and Context

The Sphinx extension `"sphinx.ext.mathjax"` appears twice in the extension list in `conf.py`.

## How has this been tested?

Untested.