### PR TITLE
Add Kedro configuration to standalone-datacatalog

### DIFF
--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.kedro]
+package_name = "{{ cookiecutter.python_package }}"
+project_name = "{{ cookiecutter.project_name }}"
+project_version = "{{ cookiecutter.kedro_version }}"
+
+[tool.isort]
+profile = "black"
+
+[tool.pytest.ini_options]
+addopts = """
+--cov-report term-missing \
+--cov src/{{ cookiecutter.python_package }} -ra"""
+
+[tool.coverage.report]
+fail_under = 0
+show_missing = true
+exclude_lines = ["pragma: no cover", "raise NotImplementedError"]


### PR DESCRIPTION
## Motivation and Context
To close gh-115.

## How has this been tested?
I haven't tested it, copy-pasted the `pyproject.toml` from spaceflights. Is there a way to specify a custom path or repo for a `kedro new` starter? Otherwise ideas for testing this are welcome.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes