### PR TITLE
Add databricks environment to pyspark-iris starter

### DIFF
--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/base/logging.yml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/base/logging.yml
@@ -44,4 +44,8 @@ loggers:
     level: INFO
 
 root:
-  handlers: [rich, info_file_handler, error_file_handler]
+  # File-based logging is disabled by default so that the starter works immediately on Databricks Repos.
+  # See https://docs.kedro.org/en/stable/logging/logging.html#disable-file-based-logging for more.
+  # To enable file-based logging, change the below line to:
+  # handlers: [rich, info_file_handler, error_file_handler]
+  handlers: [rich]

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/databricks/catalog.yml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/databricks/catalog.yml
@@ -1,0 +1,103 @@
+# Here you can define all your data sets by using simple YAML syntax.
+#
+# Documentation for this file format can be found in "The Data Catalog"
+# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+#
+# We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
+#
+# An example data set definition can look as follows:
+#
+#bikes:
+#  type: pandas.CSVDataSet
+#  filepath: "data/01_raw/bikes.csv"
+#
+#weather:
+#  type: spark.SparkDataSet
+#  filepath: s3a://your_bucket/data/01_raw/weather*
+#  file_format: csv
+#  credentials: dev_s3
+#  load_args:
+#    header: True
+#    inferSchema: True
+#  save_args:
+#    sep: '|'
+#    header: True
+#
+#scooters:
+#  type: pandas.SQLTableDataSet
+#  credentials: scooters_credentials
+#  table_name: scooters
+#  load_args:
+#    index_col: ['name']
+#    columns: ['name', 'gear']
+#  save_args:
+#    if_exists: 'replace'
+#    # if_exists: 'fail'
+#    # if_exists: 'append'
+#
+# The Data Catalog supports being able to reference the same file using two different DataSet implementations
+# (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
+# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+#
+# This is a data set used by the iris classification example pipeline provided with this starter
+# template. Please feel free to remove it once you remove the example pipeline.
+
+example_iris_data:
+  type: spark.SparkDataSet
+  filepath: data/01_raw/iris.csv
+  file_format: csv
+  load_args:
+    header: True
+    inferSchema: True
+  save_args:
+    header: True
+
+# We need to set mode to 'overwrite' in save_args so when saving the dataset it is replaced each time it is run
+# for all SparkDataSets.
+X_train@pyspark:
+  type: spark.SparkDataSet
+  filepath: data/02_intermediate/X_train.parquet
+  save_args:
+    mode: overwrite
+
+X_train@pandas:
+  type: pandas.ParquetDataSet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/X_train.parquet
+
+X_test@pyspark:
+  type: spark.SparkDataSet
+  filepath: data/02_intermediate/X_test.parquet
+  save_args:
+    mode: overwrite
+
+X_test@pandas:
+  type: pandas.ParquetDataSet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/X_test.parquet
+
+y_train@pyspark:
+  type: spark.SparkDataSet
+  filepath: data/02_intermediate/y_train.parquet
+  save_args:
+    mode: overwrite
+
+y_train@pandas:
+  type: pandas.ParquetDataSet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/y_train.parquet
+
+y_test@pyspark:
+  type: spark.SparkDataSet
+  filepath: data/02_intermediate/y_test.parquet
+  save_args:
+    mode: overwrite
+
+y_test@pandas:
+  type: pandas.ParquetDataSet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/y_test.parquet
+
+# This is an example how to use `MemoryDataSet` with Spark objects that aren't `DataFrame`'s.
+# In particular, the `assign` copy mode ensures that the `MemoryDataSet` will be assigned
+# the Spark object itself, not a deepcopy version of it, since deepcopy doesn't work with
+# Spark object generally.
+example_classifier:
+  type: MemoryDataSet
+  copy_mode: assign

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/databricks/catalog.yml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/databricks/catalog.yml
@@ -44,7 +44,7 @@
 
 example_iris_data:
   type: spark.SparkDataSet
-  filepath: data/01_raw/iris.csv
+  filepath: /dbfs/root/projects/iris-databricks/data/01_raw/iris.csv
   file_format: csv
   load_args:
     header: True
@@ -56,7 +56,7 @@ example_iris_data:
 # for all SparkDataSets.
 X_train@pyspark:
   type: spark.SparkDataSet
-  filepath: data/02_intermediate/X_train.parquet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/X_train.parquet
   save_args:
     mode: overwrite
 
@@ -66,7 +66,7 @@ X_train@pandas:
 
 X_test@pyspark:
   type: spark.SparkDataSet
-  filepath: data/02_intermediate/X_test.parquet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/X_test.parquet
   save_args:
     mode: overwrite
 
@@ -76,7 +76,7 @@ X_test@pandas:
 
 y_train@pyspark:
   type: spark.SparkDataSet
-  filepath: data/02_intermediate/y_train.parquet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/y_train.parquet
   save_args:
     mode: overwrite
 
@@ -86,7 +86,7 @@ y_train@pandas:
 
 y_test@pyspark:
   type: spark.SparkDataSet
-  filepath: data/02_intermediate/y_test.parquet
+  filepath: /dbfs/root/projects/iris-databricks/data/02_intermediate/y_test.parquet
   save_args:
     mode: overwrite
 


### PR DESCRIPTION
## Motivation and Context
 [Kedro #2722](https://github.com/kedro-org/kedro/issues/2272) highlights a bug introduced in #82. The consensus to remedy this was to introduce a databricks environment with specified dbfs filepaths as paths were not being resolved correctly.

## How has this been tested?
Following [the instructions in the docs](https://kedro.readthedocs.io/en/stable/deployment/databricks.html), with the addition of specifying the environment used. Relevant changes have been made to the docs in this PR. 

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

