### PR TITLE
Replace use of deprecated `_package_name` variable

### DIFF
--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -16,7 +16,7 @@ class SparkHooks:
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(context._project_path.name)
+            SparkSession.builder.appName(context.project_path.name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -16,7 +16,7 @@ class SparkHooks:
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(context._package_name)
+            SparkSession.builder.appName(context._project_path.name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -16,7 +16,7 @@ class SparkHooks:
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(context._project_path.name)
+            SparkSession.builder.appName(context.project_path.name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -16,7 +16,7 @@ class SparkHooks:
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(context._package_name)
+            SparkSession.builder.appName(context._project_path.name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->
Closes kedro-org/kedro-starters#123

## How has this been tested?
<!-- What testing strategies have you used? -->
1. Spun up a Codespace using https://github.com/jplane/pyspark-devcontainer
2. Verified installed Spark version is 3.4
3. Created a new project with starter `pyspark-iris`
4. Installed the requirements for the starter
5. Ran into the raised issue
6. Replaced hook with the suggested fix
7. Reran, and it works

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

