### PR TITLE
Modify filepath in PySpark Iris starter to point to dbfs:/FileStore

### DIFF
--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/databricks/catalog.yml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/databricks/catalog.yml
@@ -44,7 +44,7 @@
 
 example_iris_data:
   type: spark.SparkDataSet
-  filepath: /dbfs/root/projects/iris-databricks/data/01_raw/iris.csv
+  filepath: /dbfs/FileStore/iris-databricks/data/01_raw/iris.csv
   file_format: csv
   load_args:
     header: True


### PR DESCRIPTION
## Motivation and Context
To follow [best practices](https://docs.databricks.com/dbfs/filestore.html), we should store data that is uploaded to be processed in `dbfs:/FileStore`, not `dbfs:/root` as we currently are.

## How has this been tested?
I checked that this starter will still run on Databricks as expected when data is stored in the new location rather than the old.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

