### PR TITLE
Change default settings for spark starters

### DIFF
--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -11,7 +11,7 @@ class SparkHooks:
         """
 
         # Load the spark configuration in spark.yaml using the config loader
-        parameters = context.config_loader.get("spark*", "spark*/**")
+        parameters = context.config_loader["spark"]
         spark_conf = SparkConf().setAll(parameters.items())
 
         # Initialise the spark session

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -11,27 +11,30 @@ HOOKS = (SparkHooks(),)
 # DISABLE_HOOKS_FOR_PLUGINS = ("kedro-viz",)
 
 # Class that manages storing KedroSession data.
-# from kedro.framework.session.shelvestore import ShelveStore
-# SESSION_STORE_CLASS = ShelveStore
+# from kedro.framework.session.store import BaseSessionStore
+# SESSION_STORE_CLASS = BaseSessionStore
 # Keyword arguments to pass to the `SESSION_STORE_CLASS` constructor.
 # SESSION_STORE_ARGS = {
 #     "path": "./sessions"
 # }
 
-# Class that manages Kedro's library components.
-# from kedro.framework.context import KedroContext
-# CONTEXT_CLASS = KedroContext
-
 # Directory that holds configuration.
 # CONF_SOURCE = "conf"
 
 # Class that manages how configuration is loaded.
-# from kedro.config import TemplatedConfigLoader
-# CONFIG_LOADER_CLASS = TemplatedConfigLoader
+# from kedro.config import OmegaConfigLoader
+# CONFIG_LOADER_CLASS = OmegaConfigLoader
 # Keyword arguments to pass to the `CONFIG_LOADER_CLASS` constructor.
-# CONFIG_LOADER_ARGS = {
-#     "globals_pattern": "*globals.yml",
-# }
+CONFIG_LOADER_ARGS = {
+    "config_patterns": {
+        "spark": ["spark*/", "spark*/**"],
+        "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
+    }
+}
+
+# Class that manages Kedro's library components.
+# from kedro.framework.context import KedroContext
+# CONTEXT_CLASS = KedroContext
 
 # Class that manages the Data Catalog.
 # from kedro.io import DataCatalog

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -11,7 +11,7 @@ class SparkHooks:
         """
 
         # Load the spark configuration in spark.yaml using the config loader
-        parameters = context.config_loader.get("spark*", "spark*/**")
+        parameters = context.config_loader["spark"]
         spark_conf = SparkConf().setAll(parameters.items())
 
         # Initialise the spark session

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -25,12 +25,12 @@ HOOKS = (SparkHooks(),)
 # from kedro.config import OmegaConfigLoader
 # CONFIG_LOADER_CLASS = OmegaConfigLoader
 # Keyword arguments to pass to the `CONFIG_LOADER_CLASS` constructor.
-# CONFIG_LOADER_ARGS = {
-#       "config_patterns": {
-#           "spark" : ["spark*/"],
-#           "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
-#       }
-# }
+CONFIG_LOADER_ARGS = {
+    "config_patterns": {
+        "spark": ["spark*/", "spark*/**"],
+        "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
+    }
+}
 
 # Class that manages Kedro's library components.
 # from kedro.framework.context import KedroContext

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/hooks.py
@@ -11,7 +11,7 @@ class SparkHooks:
         """
 
         # Load the spark configuration in spark.yaml using the config loader
-        parameters = context.config_loader.get("spark*", "spark*/**")
+        parameters = context.config_loader["spark"]
         spark_conf = SparkConf().setAll(parameters.items())
 
         # Initialise the spark session

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -25,12 +25,12 @@ HOOKS = (SparkHooks(),)
 # from kedro.config import OmegaConfigLoader
 # CONFIG_LOADER_CLASS = OmegaConfigLoader
 # Keyword arguments to pass to the `CONFIG_LOADER_CLASS` constructor.
-# CONFIG_LOADER_ARGS = {
-#       "config_patterns": {
-#           "spark" : ["spark*/"],
-#           "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
-#       }
-# }
+CONFIG_LOADER_ARGS = {
+    "config_patterns": {
+        "spark": ["spark*/", "spark*/**"],
+        "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
+    }
+}
 
 # Class that manages Kedro's library components.
 # from kedro.framework.context import KedroContext


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->
```
[Omegaconf]
Hi Team,
I’d like to use Omegaconf templating for the project, but when I set CONFIG_LOADER_CLASS = OmegaConfigLoader in settings.yml and run kedro ipython, I get a ValueError: Duplicate keys found in my raw_layer.yml and .ipynb_checkpoints/raw_layer-checkpoint.yml.
settings.yml
from <my project>.hooks import SparkHooks
from kedro.config import OmegaConfigLoader

CONFIG_LOADER_CLASS = OmegaConfigLoader

CONFIG_LOADER_ARGS = {
      "config_patterns": {
          "spark": ["spark*", "spark*/**"],
          "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
          "catalog": ["catalog*", "catalog*/**", "**/catalog*"],
          "credentials": ["credentials*", "credentials*/**", "**/credentials*"],
          "logging": ["logging*", "logging*/**", "**/logging*"],
      }
}

HOOKS = (SparkHooks(),)
hooks.yml
from kedro.framework.hooks import hook_impl
from pyspark import SparkConf
from pyspark.sql import SparkSession


class SparkHooks:
    @hook_impl
    def after_context_created(self, context) -> None:
        """Initialises a SparkSession using the config
        defined in project's conf folder.
        """

        # Load the spark configuration in spark.yaml using the config loader
        parameters = context.config_loader.get("spark*", "spark*/**")
        spark_conf = SparkConf().setAll(parameters.items())

        # Initialise the spark session
        spark_session_conf = (
            SparkSession.builder.appName(context.project_path.name)
            .enableHiveSupport()
            .config(conf=spark_conf)
        )
        _spark_session = spark_session_conf.getOrCreate()
        _spark_session.sparkContext.setLogLevel("WARN")
If I use the default ConfigLoader it works as expected. Why would OmegaConf read from ipynb checkpoints? How to switch that off?
Thank you! (edited) 
```

# Fix
- Enable the config_loader_args by default, so if user choose to use `OmegaConfigLoader` it would work automatically.
- Update hooks to use `dict` interface instead of `get`
- `databricks-iris` starter is completely out of sync
## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

