### PR TITLE
Update and fix all links pointing to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kedro-starters
 
-This repository contains all official [Kedro starters](https://kedro.readthedocs.io/en/stable/get_started/starters.html). A starter can be used to bootstrap a new Kedro project as follows:
+This repository contains all official [Kedro starters](https://docs.kedro.org/en/stable/kedro_project_setup/starters.html). A starter can be used to bootstrap a new Kedro project as follows:
 
 ```bash
 kedro new --starter=<alias>
@@ -8,14 +8,14 @@ kedro new --starter=<alias>
 
 The following aliases are available:
 
-* [Alias `astro-airflow-iris`](astro-airflow-iris): The [Kedro Iris dataset example project](https://kedro.readthedocs.io/en/stable/get_started/example_project.html) with a minimal setup for deploying the pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
+* [Alias `astro-airflow-iris`](astro-airflow-iris): The [Kedro Iris dataset example project](https://docs.kedro.org/en/stable/get_started/new_project.html) with a minimal setup for deploying the pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
 
-* [Alias `pandas-iris`](pandas-iris): The [Kedro Iris dataset example project](https://kedro.readthedocs.io/en/stable/get_started/example_project.html)
+* [Alias `pandas-iris`](pandas-iris): The [Kedro Iris dataset example project](https://docs.kedro.org/en/stable/get_started/new_project.html)
 
-* [Alias `pyspark-iris`](pyspark-iris): An alternative Kedro Iris dataset example, using [PySpark](https://kedro.readthedocs.io/en/stable/tools_integration/pyspark.html)
+* [Alias `pyspark-iris`](pyspark-iris): An alternative Kedro Iris dataset example, using [PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html)
 
-* [Alias `pyspark`](pyspark): The configuration and initialisation code for a [Kedro pipeline using PySpark](https://kedro.readthedocs.io/en/stable/tools_integration/pyspark.html)
+* [Alias `pyspark`](pyspark): The configuration and initialisation code for a [Kedro pipeline using PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html)
 
-* [Alias `spaceflights`](spaceflights): The [spaceflights tutorial](https://kedro.readthedocs.io/en/stable/tutorial/spaceflights_tutorial.html) example code
+* [Alias `spaceflights`](spaceflights): The [spaceflights tutorial](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html) example code
 
-* [Alias `standalone-datacatalog`](standalone-datacatalog): A minimum setup to use the traditional [Iris dataset](https://www.kaggle.com/uciml/iris) with Kedro's [`DataCatalog`](https://kedro.readthedocs.io/en/stable/data/data_catalog.html), which is a core component of Kedro. This starter is of use in the exploratory phase of a project. For more information, read the guide to [standalone use of the `DataCatalog`](https://kedro.readthedocs.io/en/stable/get_started/standalone_use_of_datacatalog.html). This starter was formerly known as `mini-kedro`.
+* [Alias `standalone-datacatalog`](standalone-datacatalog): A minimum setup to use the traditional [Iris dataset](https://www.kaggle.com/uciml/iris) with Kedro's [`DataCatalog`](https://docs.kedro.org/en/stable/data/data_catalog.html), which is a core component of Kedro. This starter is of use in the exploratory phase of a project. For more information, read the guide to [standalone use of the `DataCatalog`](https://docs.kedro.org/en/stable/notebooks_and_ipython/kedro_as_a_data_registry.html). This starter was formerly known as `mini-kedro`.

--- a/astro-airflow-iris/README.md
+++ b/astro-airflow-iris/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The code in this repository demonstrates best practice when working with Kedro. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro Iris dataset example](https://kedro.readthedocs.io/en/stable/get_started/example_project.html). It also provides a minimum viable setup to deploy the Kedro pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
+The code in this repository demonstrates best practice when working with Kedro. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro Iris dataset example](https://docs.kedro.org/en/stable/get_started/new_project.html). It also provides a minimum viable setup to deploy the Kedro pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
 
 
 ### An example machine learning pipeline using only native `Kedro`

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/README.md
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/README.md
@@ -4,7 +4,7 @@
 
 This is your new Kedro project, which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org/) to get started.
 
 ## Rules and guidelines
 

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/README.md
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/README.md
@@ -11,7 +11,7 @@ Take a look at the [Kedro documentation](https://docs.kedro.org/) to get started
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/faq/faq.html#what-is-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 
@@ -55,7 +55,7 @@ This will `pip-compile` the contents of `src/requirements.txt` into a new file `
 
 After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -119,7 +119,7 @@ To automatically strip out all output cell contents before committing to `git`, 
 
 ## Package your Kedro project
 
-[Further information about building project documentation and packaging your project](https://kedro.readthedocs.io/en/stable/tutorial/package_a_project.html)
+[Further information about building project documentation and packaging your project](https://docs.kedro.org/en/stable/tutorial/package_a_project.html)
 
 ## Run your project in Airflow
 

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/conf/README.md
@@ -19,4 +19,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 ## Instructions
 
 ## Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/user_guide/configuration.html).
+You can find out more about configuration from the [user guide documentation](https://docs.kedro.org/en/stable/configuration/configuration_basics.html).

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,7 +1,7 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
 #
@@ -37,7 +37,7 @@
 #
 # The Data Catalog supports being able to reference the same file using two different DataSet implementations
 # (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
-# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # This is a data set used by the "Hello World" example pipeline provided with the project
 # template. Please feel free to remove it once you remove the example pipeline.

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -1,6 +1,6 @@
 """Project settings. There is no need to edit this file unless you want to change values
 from the Kedro defaults. For further information, including these default values, see
-https://kedro.readthedocs.io/en/stable/kedro_project_setup/settings.html."""
+https://docs.kedro.org/en/stable/kedro_project_setup/settings.html."""
 
 # Instantiated project hooks.
 # For example, after creating a hooks.py and defining a ProjectHooks class there, do

--- a/databricks-iris/README.md
+++ b/databricks-iris/README.md
@@ -50,7 +50,7 @@ Out of the box, Kedro's `MemoryDataSet` works with Spark's `DataFrame`. However,
 ![Iris Pipeline Visualisation](./images/iris_pipeline.png)
 
 This Kedro starter uses the simple and familiar [Iris dataset](https://www.kaggle.com/uciml/iris). It contains the code for an example machine learning pipeline that runs a 1-nearest neighbour classifier to classify an iris.
-[Transcoding](https://kedro.readthedocs.io/en/stable/data/data_catalog.html#transcoding-datasets) is used to convert the Spark Dataframes into pandas DataFrames after splitting the data into training and testing sets.
+[Transcoding](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html#read-the-same-file-using-two-different-datasets) is used to convert the Spark Dataframes into pandas DataFrames after splitting the data into training and testing sets.
 
 The pipeline includes:
 

--- a/databricks-iris/{{ cookiecutter.repo_name }}/README.md
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/README.md
@@ -4,14 +4,14 @@
 
 This is your new Kedro project, which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 
 ## Rules and guidelines
 
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/faq/faq.html#what-is-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 
@@ -55,7 +55,7 @@ This will `pip-compile` the contents of `src/requirements.txt` into a new file `
 
 After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -119,4 +119,4 @@ To automatically strip out all output cell contents before committing to `git`, 
 
 ## Package your Kedro project
 
-[Further information about building project documentation and packaging your project](https://kedro.readthedocs.io/en/stable/tutorial/package_a_project.html)
+[Further information about building project documentation and packaging your project](https://docs.kedro.org/en/stable/tutorial/package_a_project.html)

--- a/databricks-iris/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 ## Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/user_guide/configuration.html).
+You can find out more about configuration from the [user guide documentation](https://docs.kedro.org/en/stable/configuration/configuration_basics.html).

--- a/databricks-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,7 +1,7 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
 #
@@ -37,7 +37,7 @@
 #
 # The Data Catalog supports being able to reference the same file using two different DataSet implementations
 # (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
-# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # This is a data set used by the iris classification example pipeline provided with this starter
 # template. Please feel free to remove it once you remove the example pipeline.

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/README.md
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-[Transcoding](https://kedro.readthedocs.io/en/stable/data/data_catalog.html#transcoding-datasets) is used to convert the Spark DataFrames into pandas DataFrames after splitting the data into training and testing sets.
+[Transcoding](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html#read-the-same-file-using-two-different-datasets) is used to convert the Spark DataFrames into pandas DataFrames after splitting the data into training and testing sets.
 
 This pipeline:
 1. splits the data into training dataset and testing dataset using a configurable ratio found in `conf/base/parameters.yml`

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -1,6 +1,6 @@
 """Project settings. There is no need to edit this file unless you want to change values
 from the Kedro defaults. For further information, including these default values, see
-https://kedro.readthedocs.io/en/stable/kedro_project_setup/settings.html."""
+https://docs.kedro.org/en/stable/kedro_project_setup/settings.html."""
 
 # Instantiated project hooks.
 from {{cookiecutter.python_package}}.hooks import SparkHooks  # noqa: import-outside-toplevel

--- a/pandas-iris/README.md
+++ b/pandas-iris/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The code in this repository demonstrates best practice when working with Kedro. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro Iris dataset example](https://kedro.readthedocs.io/en/stable/get_started/example_project.html).
+The code in this repository demonstrates best practice when working with Kedro. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro Iris dataset example](https://docs.kedro.org/en/stable/get_started/new_project.html).
 
 
 ### An example pipeline using only native `Kedro`

--- a/pandas-iris/{{ cookiecutter.repo_name }}/README.md
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/README.md
@@ -4,14 +4,14 @@
 
 This is your new Kedro project, which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org/) to get started.
 
 ## Rules and guidelines
 
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/faq/faq.html#what-is-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 
@@ -55,7 +55,7 @@ This will `pip-compile` the contents of `src/requirements.txt` into a new file `
 
 After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -119,4 +119,4 @@ To automatically strip out all output cell contents before committing to `git`, 
 
 ## Package your Kedro project
 
-[Further information about building project documentation and packaging your project](https://kedro.readthedocs.io/en/stable/tutorial/package_a_project.html)
+[Further information about building project documentation and packaging your project](https://docs.kedro.org/en/stable/tutorial/package_a_project.html)

--- a/pandas-iris/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 ## Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/user_guide/configuration.html).
+You can find out more about configuration from the [user guide documentation](https://docs.kedro.org/en/stable/configuration/configuration_basics.html).

--- a/pandas-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,7 +1,7 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
 #
@@ -37,7 +37,7 @@
 #
 # The Data Catalog supports being able to reference the same file using two different DataSet implementations
 # (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
-# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # This is a data set used by the "Hello World" example pipeline provided with the project
 # template. Please feel free to remove it once you remove the example pipeline.

--- a/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -1,6 +1,6 @@
 """Project settings. There is no need to edit this file unless you want to change values
 from the Kedro defaults. For further information, including these default values, see
-https://kedro.readthedocs.io/en/stable/kedro_project_setup/settings.html."""
+https://docs.kedro.org/en/stable/kedro_project_setup/settings.html."""
 
 # Instantiated project hooks.
 # For example, after creating a hooks.py and defining a ProjectHooks class there, do

--- a/pyspark-iris/README.md
+++ b/pyspark-iris/README.md
@@ -2,17 +2,17 @@
 
 ## Introduction
 
-The code in this repository demonstrates best practice when working with Kedro and PySpark. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro documentation about how to work with PySpark](https://kedro.readthedocs.io/en/stable/tools_integration/pyspark.html).
+The code in this repository demonstrates best practice when working with Kedro and PySpark. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro documentation about how to work with PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html).
 
 ## Getting started
 
-The starter template can be used to start a new project using the [`starter` option](https://kedro.readthedocs.io/en/stable/get_started/starters.html) in `kedro new`:
+The starter template can be used to start a new project using the [`starter` option](https://docs.kedro.org/en/stable/kedro_project_setup/starters.html) in `kedro new`:
 
 ```bash
 kedro new --starter=pyspark-iris
 ```
 
-As a reference, the [How to use Kedro on a Databricks cluster](https://github.com/kedro-org/kedro/blob/develop/docs/source/deployment/databricks.md) tutorial bootstraps the project using this starter.
+As a reference, the [How to use Kedro on a Databricks cluster](https://docs.kedro.org/en/stable/deployment/databricks/index.html) tutorial bootstraps the project using this starter.
 
 ## Features
 
@@ -34,7 +34,7 @@ Out of the box, Kedro's `MemoryDataSet` works with Spark's `DataFrame`. However,
 ![Iris Pipeline Visualisation](./images/iris_pipeline.png)
 
 This Kedro starter uses the simple and familiar [Iris dataset](https://www.kaggle.com/uciml/iris). It contains the code for an example machine learning pipeline that runs a 1-nearest neighbour classifier to classify an iris. 
-[Transcoding](https://kedro.readthedocs.io/en/stable/data/data_catalog.html#transcoding-datasets) is used to convert the Spark Dataframes into pandas DataFrames after splitting the data into training and testing sets.
+[Transcoding](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html#read-the-same-file-using-two-different-datasets) is used to convert the Spark Dataframes into pandas DataFrames after splitting the data into training and testing sets.
 
 The pipeline includes:
 

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/README.md
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/README.md
@@ -4,14 +4,14 @@
 
 This is your new Kedro project, which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 
 ## Rules and guidelines
 
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/faq/faq.html#what-is-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 
@@ -55,7 +55,7 @@ This will `pip-compile` the contents of `src/requirements.txt` into a new file `
 
 After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -119,4 +119,4 @@ To automatically strip out all output cell contents before committing to `git`, 
 
 ## Package your Kedro project
 
-[Further information about building project documentation and packaging your project](https://kedro.readthedocs.io/en/stable/tutorial/package_a_project.html)
+[Further information about building project documentation and packaging your project](https://docs.kedro.org/en/stable/tutorial/package_a_project.html)

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 ## Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/user_guide/configuration.html).
+You can find out more about configuration from the [user guide documentation](https://docs.kedro.org/en/stable/configuration/configuration_basics.html).

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,7 +1,7 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
 #
@@ -37,7 +37,7 @@
 #
 # The Data Catalog supports being able to reference the same file using two different DataSet implementations
 # (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
-# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # This is a data set used by the iris classification example pipeline provided with this starter
 # template. Please feel free to remove it once you remove the example pipeline.

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/conf/base/spark.yml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/conf/base/spark.yml
@@ -4,5 +4,5 @@ spark.driver.maxResultSize: 3g
 spark.hadoop.fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
 spark.sql.execution.arrow.pyspark.enabled: true
 
-# https://kedro.readthedocs.io/en/stable/tools_integration/pyspark.html#tips-for-maximising-concurrency-using-threadrunner
+# https://docs.kedro.org/en/stable/integrations/pyspark_integration.html#tips-for-maximising-concurrency-using-threadrunner
 spark.scheduler.mode: FAIR

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/README.md
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-[Transcoding](https://kedro.readthedocs.io/en/stable/data/data_catalog.html#transcoding-datasets) is used to convert the Spark DataFrames into pandas DataFrames after splitting the data into training and testing sets.
+[Transcoding](https://docs.kedro.org/en/stable/data/data_catalog_yaml_examples.html#read-the-same-file-using-two-different-datasets) is used to convert the Spark DataFrames into pandas DataFrames after splitting the data into training and testing sets.
 
 This pipeline:
 1. splits the data into training dataset and testing dataset using a configurable ratio found in `conf/base/parameters.yml`

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -1,6 +1,6 @@
 """Project settings. There is no need to edit this file unless you want to change values
 from the Kedro defaults. For further information, including these default values, see
-https://kedro.readthedocs.io/en/stable/kedro_project_setup/settings.html."""
+https://docs.kedro.org/en/stable/kedro_project_setup/settings.html."""
 
 # Instantiated project hooks.
 from {{cookiecutter.python_package}}.hooks import SparkHooks  # noqa: import-outside-toplevel

--- a/pyspark/README.md
+++ b/pyspark/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The code in this repository demonstrates best practice when working with Kedro and PySpark. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro documentation about how to work with PySpark](https://kedro.readthedocs.io/en/stable/tools_integration/pyspark.html).
+The code in this repository demonstrates best practice when working with Kedro and PySpark. It contains a Kedro starter template with some initial configuration and an example pipeline, and originates from the [Kedro documentation about how to work with PySpark](https://docs.kedro.org/en/stable/integrations/pyspark_integration.html).
 
 ## Features
 

--- a/pyspark/{{ cookiecutter.repo_name }}/README.md
+++ b/pyspark/{{ cookiecutter.repo_name }}/README.md
@@ -4,14 +4,14 @@
 
 This is your new Kedro project, which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org/) to get started.
 
 ## Rules and guidelines
 
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/faq/faq.html#what-is-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 
@@ -55,7 +55,7 @@ This will `pip-compile` the contents of `src/requirements.txt` into a new file `
 
 After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -119,4 +119,4 @@ To automatically strip out all output cell contents before committing to `git`, 
 
 ## Package your Kedro project
 
-[Further information about building project documentation and packaging your project](https://kedro.readthedocs.io/en/stable/tutorial/package_a_project.html)
+[Further information about building project documentation and packaging your project](https://docs.kedro.org/en/stable/tutorial/package_a_project.html)

--- a/pyspark/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/pyspark/{{ cookiecutter.repo_name }}/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 ## Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/user_guide/configuration.html).
+You can find out more about configuration from the [user guide documentation](https://docs.kedro.org/en/stable/configuration/configuration_basics.html).

--- a/pyspark/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/pyspark/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,11 +1,11 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/latest/data/data_catalog.html
 #
 # We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
 #
 # The Data Catalog supports being able to reference the same file using two different DataSet implementations
 # (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
-# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# https://docs.kedro.org/en/latest/data/data_catalog.html
 #

--- a/pyspark/{{ cookiecutter.repo_name }}/conf/base/spark.yml
+++ b/pyspark/{{ cookiecutter.repo_name }}/conf/base/spark.yml
@@ -4,5 +4,5 @@ spark.driver.maxResultSize: 3g
 spark.hadoop.fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
 spark.sql.execution.arrow.pyspark.enabled: true
 
-# https://kedro.readthedocs.io/en/stable/tools_integration/pyspark.html#tips-for-maximising-concurrency-using-threadrunner
+# https://docs.kedro.org/en/stable/integrations/pyspark_integration.html#tips-for-maximising-concurrency-using-threadrunner
 spark.scheduler.mode: FAIR

--- a/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -1,6 +1,6 @@
 """Project settings. There is no need to edit this file unless you want to change values
 from the Kedro defaults. For further information, including these default values, see
-https://kedro.readthedocs.io/en/stable/kedro_project_setup/settings.html."""
+https://docs.kedro.org/en/stable/kedro_project_setup/settings.html."""
 
 # Instantiated project hooks.
 from {{cookiecutter.python_package}}.hooks import SparkHooks  # noqa: import-outside-toplevel

--- a/spaceflights/README.md
+++ b/spaceflights/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This is a completed version of the [spaceflights tutorial project](https://kedro.readthedocs.io/en/stable/tutorial/spaceflights_tutorial.html) described in the [online Kedro documentation](https://kedro.readthedocs.io), including the data required to run the project.
+This is a completed version of the [spaceflights tutorial project](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html) described in the [online Kedro documentation](https://docs.kedro.org), including the data required to run the project.
 
-The tutorial works through the steps necessary to create this project. To learn the most about Kedro, we recommend that you start with a blank template as the tutorial describes, and follow the workflow. However, if you prefer to read swiftly through the documentation and get to work on the code, you may want to generate a new Kedro project using this [starter](https://kedro.readthedocs.io/en/stable/get_started/starters.html) because the steps have been done for you.
+The tutorial works through the steps necessary to create this project. To learn the most about Kedro, we recommend that you start with a blank template as the tutorial describes, and follow the workflow. However, if you prefer to read swiftly through the documentation and get to work on the code, you may want to generate a new Kedro project using this [starter](https://docs.kedro.org/en/stable/kedro_project_setup/starters.html) because the steps have been done for you.
 
-To use this starter, create a new Kedro project using the commands below. To make sure you have the required dependencies, run it in your virtual environment (see [our documentation about virtual environments](https://kedro.readthedocs.io/en/stable/get_started/prerequisites.html#virtual-environments) for guidance on how to get set up):
+To use this starter, create a new Kedro project using the commands below. To make sure you have the required dependencies, run it in your virtual environment (see [our documentation about virtual environments](https://docs.kedro.org/en/stable/get_started/install.html#virtual-environments) for guidance on how to get set up):
 
 ```bash
 pip install kedro

--- a/spaceflights/{{ cookiecutter.repo_name }}/README.md
+++ b/spaceflights/{{ cookiecutter.repo_name }}/README.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-This is your new Kedro project for the [spaceflights tutorial](https://kedro.readthedocs.io/en/stable/tutorial/spaceflights_tutorial.html), which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
+This is your new Kedro project for the [spaceflights tutorial](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html), which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 
 ## Rules and guidelines
 
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/faq/faq.html#what-is-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 

--- a/spaceflights/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/spaceflights/{{ cookiecutter.repo_name }}/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 ## Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/kedro_project_setup/configuration.html).
+You can find out more about configuration from the [user guide documentation](https://docs.kedro.org/en/stable/configuration/configuration_basics.html).

--- a/spaceflights/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/spaceflights/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,7 +1,7 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/stable/data/data_catalog.html
 #
 # We support interacting with a variety of data stores including local file systems, cloud, network and HDFS
 #
@@ -37,7 +37,7 @@
 #
 # The Data Catalog supports being able to reference the same file using two different DataSet implementations
 # (transcoding), templating and a way to reuse arguments that are frequently repeated. See more here:
-# https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# https://docs.kedro.org/en/stable/data/data_catalog.html
 
 companies:
   type: pandas.CSVDataSet

--- a/spaceflights/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
+++ b/spaceflights/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/settings.py
@@ -1,6 +1,6 @@
 """Project settings. There is no need to edit this file unless you want to change values
 from the Kedro defaults. For further information, including these default values, see
-https://kedro.readthedocs.io/en/stable/kedro_project_setup/settings.html."""
+https://docs.kedro.org/en/stable/kedro_project_setup/settings.html."""
 
 # Instantiated project hooks.
 # For example, after creating a hooks.py and defining a ProjectHooks class there, do

--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
@@ -42,7 +42,7 @@ Let's assume that the new project is created at `/path/to/your/project`.
 cp -fR {conf,data} `/path/to/your/project`
 ```
 
-Congratulations! You now have a Kedro project setup with a fully functional `DataCatalog`. You can then explore the documentation on how to write [nodes and pipelines](https://kedro.readthedocs.io/en/latest/nodes_and_pipelines/nodes.html) to process this data.
+Congratulations! You now have a Kedro project setup with a fully functional `DataCatalog`. You can then explore the documentation on how to write [nodes and pipelines](https://docs.kedro.org/en/latest/nodes_and_pipelines/nodes.html) to process this data.
 
 ### Limitation
 

--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-This is a bare minimum setup for you to use a core component of Kedro in the exploratory phase of a project. Specifically, it enables you to use Kedro to configure and explore data sources in Jupyter notebook through the [DataCatalog](https://kedro.readthedocs.io/en/stable/data/data_catalog.html) feature.
+This is a bare minimum setup for you to use a core component of Kedro in the exploratory phase of a project. Specifically, it enables you to use Kedro to configure and explore data sources in Jupyter notebook through the [DataCatalog](https://docs.kedro.org/en/stable/data/data_catalog.html) feature.
 Later on, you can build a full pipeline using the same configuration.
 
 The project was generated using `Kedro {{ cookiecutter.kedro_version }}`.
@@ -22,7 +22,7 @@ jupyter notebook
 ```
 
 At the root directory, you will find an example notebook showing how to instantiate the `DataCatalog` and interact with the included example dataset.
-You can edit the [conf/catalog.yml](./conf/base/catalog.yml) file to add more datasets to the `DataCatalog` for further exploration. To see more examples on how to use the `DataCatalog`, please visit the [DataCatalog documentation](https://kedro.readthedocs.io/en/latest/data/data_catalog.html).
+You can edit the [conf/catalog.yml](./conf/base/catalog.yml) file to add more datasets to the `DataCatalog` for further exploration. To see more examples on how to use the `DataCatalog`, please visit the [DataCatalog documentation](https://docs.kedro.org/en/stable/data/data_catalog.html).
 
 ## Transition to a full Kedro project
 

--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/conf/README.md
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/conf/README.md
@@ -17,4 +17,4 @@ The `base` folder is for shared configuration, such as non-sensitive and project
 WARNING: Please do not put access credentials in the base configuration folder.
 
 ## Find out more
-You can find out more about configuration from the [Kedro documentation](https://kedro.readthedocs.io/).
+You can find out more about configuration from the [Kedro documentation](https://docs.kedro.org).

--- a/standalone-datacatalog/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/standalone-datacatalog/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -1,7 +1,7 @@
 # Here you can define all your data sets by using simple YAML syntax.
 #
 # Documentation for this file format can be found in "The Data Catalog"
-# Link: https://kedro.readthedocs.io/en/stable/data/data_catalog.html
+# Link: https://docs.kedro.org/en/latest/data/data_catalog.html
 
 example_iris_data:
   type: pandas.CSVDataSet


### PR DESCRIPTION
## Motivation and Context
I noticed the links in the starters are all still pointing to `kedro.readthedocs` and some of them are not even redirected properly. I fixed them all in this PR.

## How has this been tested?


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

