### PR TITLE
Strip `pyproject.toml` and `requirements.txt` in starters so it can be used by add-ons

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab~=3.0
@@ -6,7 +5,3 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataset]~=1.0
 kedro-airflow~=0.5
 kedro-telemetry~=0.2.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290

--- a/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab~=3.0
@@ -6,7 +5,3 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[spark.SparkDataset, pandas.ParquetDataset]~=1.0
 kedro-telemetry~=0.2.0
 numpy~=1.21
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290

--- a/pandas-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/pandas-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/pandas-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab~=3.0
@@ -6,7 +5,3 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-viz @ git+https://github.com/kedro-org/kedro-viz.git@main#subdirectory=package
 kedro-datasets[pandas.CSVDataset]~=1.0
 kedro-telemetry~=0.2.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/pyspark-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/pyspark-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab~=3.0
@@ -6,7 +5,3 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[spark.SparkDataset, pandas.ParquetDataset]~=1.0
 kedro-telemetry~=0.2.0
 numpy~=1.21
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290

--- a/pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/pyspark/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/pyspark/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,12 +1,6 @@
-black~=22.0
-ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab~=3.0
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[spark.SparkDataset]~=1.0
 kedro-telemetry~=0.2.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,5 +1,3 @@
-black~=22.0
-ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab_server>=2.11.1
@@ -8,9 +6,5 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, plotly.PlotlyDataset, plotly.JSONDataset, matplotlib.MatplotlibWriter]~=1.0
 kedro-telemetry~=0.2.0
 kedro-viz @ git+https://github.com/kedro-org/kedro-viz.git@main#subdirectory=package
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290
 scikit-learn~=1.0
 seaborn~=0.12.1

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,5 +1,3 @@
-black~=22.0
-ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab_server>=2.11.1
@@ -8,8 +6,4 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset]~=1.0
 kedro-telemetry~=0.2.0
 kedro-viz @ git+https://github.com/kedro-org/kedro-viz.git@main#subdirectory=package
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290
 scikit-learn~=1.0

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -37,27 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab_server>=2.11.1
@@ -7,9 +6,5 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, spark.SparkDataset, plotly.PlotlyDataset, plotly.JSONDataset, matplotlib.MatplotlibWriter]~=1.0
 kedro-telemetry~=0.2.0
 kedro-viz @ git+https://github.com/kedro-org/kedro-viz.git@main#subdirectory=package
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290
 scikit-learn~=1.0
 seaborn~=0.12.1

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,4 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-
+add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -12,19 +12,6 @@ dynamic = ["dependencies", "version"]
 
 [project.entry-points."kedro.hooks"]
 
-[project.optional-dependencies]
-docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
-    "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
-]
-
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}
 version = {attr = "{{ cookiecutter.python_package }}.__version__"}
@@ -38,26 +25,3 @@ package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
 
-[tool.pytest.ini_options]
-addopts = """
---cov-report term-missing \
---cov src/{{ cookiecutter.python_package }} -ra"""
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
-
-[tool.ruff]
-line-length = 88
-show-fixes = true
-select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
-    "T201", # Print Statement
-]
-ignore = ["E501"]  # Black takes care of line-too-long

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.0
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0
 jupyterlab_server>=2.11.1
@@ -7,8 +6,4 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, spark.SparkDataset]~=1.0
 kedro-telemetry~=0.2.0
 kedro-viz @ git+https://github.com/kedro-org/kedro-viz.git@main#subdirectory=package
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.0.290
 scikit-learn~=1.0


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->

Related to: https://github.com/kedro-org/kedro/pull/3169
Related comment: https://github.com/kedro-org/kedro/pull/3169#discussion_r1372996593

The `pyproject.toml` and `requirements.txt` files in the starters should contain the minimum so that they don't contain any "add-ons" related stuff by default.

## Development Notes
<!-- What testing strategies have you used? -->

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

