### PR TITLE
Add `3.11` builds to `kedro-starters`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       python_version:
         type: string
     docker:
-      - image: circleci/python:<<parameters.python_version>>
+      - image: cimg/python:<<parameters.python_version>>
 
 commands:
   setup_python_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,10 @@ commands:
       - checkout
       - run:
           name: Install pip setuptools
-          command: python -m pip install -U "pip>=21.2" "setuptools>=38.0" wheel
+          command: python -m pip install -U pip setuptools wheel
       - run:
           name: Install test requirements
-          command: sudo pip install -r test_requirements.txt
+          command: pip install -r test_requirements.txt
       - run:
           name: Pip freeze
           command: pip freeze

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ executors:
       - image: circleci/python:<<parameters.python_version>>
 
 commands:
-##
   setup_python_env:
     description: Setup Python environment
     steps:
@@ -22,14 +21,13 @@ commands:
       - run:
           name: Install Python dependencies
           command: pip install -r test_requirements.txt -U
-            
+
       - run:
           name: Echo package versions
           command: |
             python -V
             pip -V
             kedro -V
-##
 
   setup_requirements:
     parameters:
@@ -117,7 +115,7 @@ commands:
     steps:
       - run:
           command: |
-            conda activate kedro-starters 
+            conda activate kedro-starters
             behave features/run.feature
 
   win_e2e_lint:
@@ -125,7 +123,7 @@ commands:
     steps:
       - run:
           command: |
-            conda activate kedro-starters 
+            conda activate kedro-starters
             behave features/lint.feature
 
 jobs:
@@ -206,18 +204,18 @@ workflows:
       - run:
           matrix:
             parameters:
-              python_version: [ "3.8", "3.9", "3.10" ]
+              python_version: [ "3.8", "3.9", "3.10", "3.11" ]
       - lint:
           matrix:
             parameters:
-              python_version: [ "3.8", "3.9", "3.10" ]
+              python_version: [ "3.8", "3.9", "3.10", "3.11" ]
 
       - win_run:
           matrix:
                 parameters:
-                  python_version: [ "3.8", "3.9", "3.10" ]
+                  python_version: [ "3.8", "3.9", "3.10", "3.11" ]
 
       - win_lint:
           matrix:
                 parameters:
-                  python_version: [ "3.8", "3.9", "3.10" ]
+                  python_version: [ "3.8", "3.9", "3.10", "3.11" ]


### PR DESCRIPTION
## Motivation and Context
Closes #160 

## How has this been tested?
- Updated the image type, because `circleci/python:3.11` doesn't exist
- Updated the command to install pip, setuptools and wheel
- All builds passed.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

