### PR TITLE
Add `credentials.yml` placeholder files to all spaceflights projects

### DIFF
--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/conf/local/credentials.yml
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/conf/local/credentials.yml
@@ -1,0 +1,16 @@
+# Here you can define credentials for different data sets and environment.
+#
+#
+# Example:
+#
+# dev_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# prod_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# dev_sql:
+#     username: admin
+#     password: admin

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/conf/local/credentials.yml
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/conf/local/credentials.yml
@@ -1,0 +1,16 @@
+# Here you can define credentials for different data sets and environment.
+#
+#
+# Example:
+#
+# dev_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# prod_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# dev_sql:
+#     username: admin
+#     password: admin

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/conf/local/credentials.yml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/conf/local/credentials.yml
@@ -1,0 +1,16 @@
+# Here you can define credentials for different data sets and environment.
+#
+#
+# Example:
+#
+# dev_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# prod_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# dev_sql:
+#     username: admin
+#     password: admin


### PR DESCRIPTION
## Motivation and Context
While working on https://github.com/kedro-org/kedro/issues/3220 I noticed that the new spaceflights projects don't have the placeholder `credentials.yml` file. I'm guessing these were not committed when I created the projects because they are ignored in `.gitignore`. The original `spaceflights-pandas` project contains a `credentials.yml` so I'm adding it to the other projects for consistency.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

