### PR TITLE
Add example_pipeline to starters hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ __pycache__/
 # C extensions
 *.so
 
+### macOS
+*.DS_Store
+.AppleDouble
+.LSOverride
+.Trashes
+
 # Distribution / packaging
 .Python
 build/

--- a/spaceflights-pandas-viz/cookiecutter.json
+++ b/spaceflights-pandas-viz/cookiecutter.json
@@ -3,5 +3,6 @@
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
-    "add_ons": "none"
+    "add_ons": "none",
+    "example_pipeline": "No"
 }

--- a/spaceflights-pandas-viz/cookiecutter.json
+++ b/spaceflights-pandas-viz/cookiecutter.json
@@ -4,5 +4,5 @@
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
     "add_ons": "none",
-    "example_pipeline": "No"
+    "example_pipeline": "no"
 }

--- a/spaceflights-pandas-viz/hooks/post_gen_project.py
+++ b/spaceflights-pandas-viz/hooks/post_gen_project.py
@@ -13,9 +13,10 @@ def main(selected_add_ons):
     requirements_file_path = current_dir / "requirements.txt"
     pyproject_file_path = current_dir / "pyproject.toml"
     python_package_name = '{{ cookiecutter.python_package }}'
+    example_pipeline = "{{ cookiecutter.example_pipeline }}"
 
     # Handle template directories and requirements according to selected add-ons
-    setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name)
+    setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name, example_pipeline)
 
     # Sort requirements.txt file in alphabetical order
     sort_requirements(requirements_file_path)

--- a/spaceflights-pandas-viz/hooks/post_gen_project.py
+++ b/spaceflights-pandas-viz/hooks/post_gen_project.py
@@ -5,7 +5,6 @@ from kedro.templates.project.hooks.utils import (
     setup_template_add_ons,
     sort_requirements,
 )
-from kedro.framework.cli.starters import _parse_add_ons_input
 
 
 def main(selected_add_ons):

--- a/spaceflights-pandas/cookiecutter.json
+++ b/spaceflights-pandas/cookiecutter.json
@@ -3,5 +3,6 @@
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
-    "add_ons": "none"
+    "add_ons": "none",
+    "example_pipeline": "No"
 }

--- a/spaceflights-pandas/cookiecutter.json
+++ b/spaceflights-pandas/cookiecutter.json
@@ -4,5 +4,5 @@
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
     "add_ons": "none",
-    "example_pipeline": "No"
+    "example_pipeline": "no"
 }

--- a/spaceflights-pandas/hooks/post_gen_project.py
+++ b/spaceflights-pandas/hooks/post_gen_project.py
@@ -5,7 +5,6 @@ from kedro.templates.project.hooks.utils import (
     setup_template_add_ons,
     sort_requirements,
 )
-from kedro.framework.cli.starters import _parse_add_ons_input
 
 
 def main(selected_add_ons):

--- a/spaceflights-pandas/hooks/post_gen_project.py
+++ b/spaceflights-pandas/hooks/post_gen_project.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     # Get the selected add-ons from cookiecutter
     selected_add_ons = "{{ cookiecutter.add_ons }}"
 
-    # Execute the script only if the Pyspark add-on is selected.
+    # Execute the script only if the add-on is selected.
     # This ensures the script doesn't run with kedro new --starter but only with the add-ons flow option.
-    if "Pyspark" in selected_add_ons and "Kedro Viz" in selected_add_ons:
+    if selected_add_ons != "none":
         main(selected_add_ons)

--- a/spaceflights-pyspark-viz/cookiecutter.json
+++ b/spaceflights-pyspark-viz/cookiecutter.json
@@ -3,5 +3,6 @@
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
-    "add_ons": "none"
+    "add_ons": "none",
+    "example_pipeline": "No"
 }

--- a/spaceflights-pyspark-viz/cookiecutter.json
+++ b/spaceflights-pyspark-viz/cookiecutter.json
@@ -4,5 +4,5 @@
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
     "add_ons": "none",
-    "example_pipeline": "No"
+    "example_pipeline": "no"
 }

--- a/spaceflights-pyspark-viz/hooks/post_gen_project.py
+++ b/spaceflights-pyspark-viz/hooks/post_gen_project.py
@@ -5,7 +5,6 @@ from kedro.templates.project.hooks.utils import (
     setup_template_add_ons,
     sort_requirements,
 )
-from kedro.framework.cli.starters import _parse_add_ons_input
 
 
 def main(selected_add_ons):

--- a/spaceflights-pyspark/cookiecutter.json
+++ b/spaceflights-pyspark/cookiecutter.json
@@ -3,5 +3,6 @@
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
-    "add_ons": "none"
+    "add_ons": "none",
+    "example_pipeline": "No"
 }

--- a/spaceflights-pyspark/cookiecutter.json
+++ b/spaceflights-pyspark/cookiecutter.json
@@ -4,5 +4,5 @@
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
     "add_ons": "none",
-    "example_pipeline": "No"
+    "example_pipeline": "no"
 }

--- a/spaceflights-pyspark/hooks/post_gen_project.py
+++ b/spaceflights-pyspark/hooks/post_gen_project.py
@@ -13,9 +13,10 @@ def main(selected_add_ons):
     requirements_file_path = current_dir / "requirements.txt"
     pyproject_file_path = current_dir / "pyproject.toml"
     python_package_name = '{{ cookiecutter.python_package }}'
+    example_pipeline = "{{ cookiecutter.example_pipeline }}"
 
     # Handle template directories and requirements according to selected add-ons
-    setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name)
+    setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name, example_pipeline)
 
     # Sort requirements.txt file in alphabetical order
     sort_requirements(requirements_file_path)

--- a/spaceflights-pyspark/hooks/post_gen_project.py
+++ b/spaceflights-pyspark/hooks/post_gen_project.py
@@ -5,7 +5,6 @@ from kedro.templates.project.hooks.utils import (
     setup_template_add_ons,
     sort_requirements,
 )
-from kedro.framework.cli.starters import _parse_add_ons_input
 
 
 def main(selected_add_ons):


### PR DESCRIPTION
## Motivation and Context
This PR adds `example_pipeline` option to `post_gen_project.py` hooks for 3 starters (Viz, PySpark, both) and adds `post_gen_project.py` hook to Spaceflights-pandas starter. Needs to be done to be compatible with adding example option in [3295](https://github.com/kedro-org/kedro/pull/3295)

## How has this been tested?
Tested manually with `3076-add-an-option-to-get-an-example-pipeline` branch 

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

