### PR TITLE
Fix databricks entry point

### DIFF
--- a/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 dynamic = ["dependencies", "version"]
 
 [project.scripts]
-{{ cookiecutter.repo_name }} = "{{ cookiecutter.python_package }}.__main__:main"
+databricks_run = "{{ cookiecutter.python_package }}.databricks_run:main"
 
 [project.entry-points."kedro.hooks"]
 


### PR DESCRIPTION
## Motivation and Context
To deploy kedro projects in Databricks, we need to use specific entry point, our manual using `databricks_run` name and in starter we put special code in `databricks_run.py` file. This PR changes common entry point pattern used in all starters to specific for Databricks:
`databricks_run = "{{ cookiecutter.python_package }}.databricks_run:main"
`
## How has this been tested?
The new entry point configuration has been tested manually on Databricks.
Deployment was made using Databricks job, following this [manual](https://docs.kedro.org/en/latest/deployment/databricks/databricks_deployment_workflow.html#create-an-entry-point-for-databricks)


## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

