### PR TITLE
Pin Pip and fix lint e2e tests

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -36,9 +36,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pip and test requirements
+      - name: Install test requirements
         run: |
-          python -m pip install pip==23.2  # 23.3 has dependencies resolution bug
           make install-test-requirements        
       - name: Add MSBuild to PATH
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -36,8 +36,10 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install test requirements
-        run: make install-test-requirements
+      - name: Install pip and test requirements
+        run: |
+          python -m pip install pip==23.2  # 23.3 has dependencies resolution bug
+          make install-test-requirements        
       - name: Add MSBuild to PATH
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,0 @@
-FROM gitpod/workspace-full:2023-05-08-21-16-55
-
-# Some datasets work on 3.8 only
-RUN pyenv install 3.8.15\
-    && pyenv global 3.8.15

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full:2023-05-08-21-16-55
+
+# Some datasets work on 3.8 only
+RUN pyenv install 3.8.15\
+    && pyenv global 3.8.15

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,9 @@
 
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
+image:
+  file: .gitpod.Dockerfile
+
 tasks:
   - init: |
       make sign-off

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,9 +4,8 @@
 
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
-image:
-  file: .gitpod.Dockerfile
-
+image: gitpod/workspace-python-3.10
+  
 tasks:
   - init: |
       make sign-off

--- a/features/environment.py
+++ b/features/environment.py
@@ -79,6 +79,17 @@ def _create_tmp_dir() -> Path:
 def before_scenario(context, scenario):
     """Environment preparation before each test is run."""
     kedro_install_venv_dir = create_new_venv()
+    context.venv_dir = kedro_install_venv_dir
+
+    if os.name == "posix":
+        bin_dir = context.venv_dir / "bin"
+    else:
+        bin_dir = context.venv_dir / "Scripts"
+
+    context.bin_dir = bin_dir
+    context.pip = str(bin_dir / "pip")
+    context.kedro = str(bin_dir / "kedro")
+    context.python = str(bin_dir / "python")
 
     # Fix Pip version
     call(
@@ -94,18 +105,6 @@ def before_scenario(context, scenario):
         env=context.env,
     )
 
-
-    context.venv_dir = kedro_install_venv_dir
-
-    if os.name == "posix":
-        bin_dir = context.venv_dir / "bin"
-    else:
-        bin_dir = context.venv_dir / "Scripts"
-
-    context.bin_dir = bin_dir
-    context.pip = str(bin_dir / "pip")
-    context.kedro = str(bin_dir / "kedro")
-    context.python = str(bin_dir / "python")
 
     starters_root = Path(__file__).parents[1]
     starter_names = [

--- a/features/environment.py
+++ b/features/environment.py
@@ -80,6 +80,7 @@ def before_scenario(context, scenario):
     """Environment preparation before each test is run."""
     kedro_install_venv_dir = create_new_venv()
     context.venv_dir = kedro_install_venv_dir
+    context.env = os.environ.copy()
 
     if os.name == "posix":
         bin_dir = context.venv_dir / "bin"

--- a/features/lint.feature
+++ b/features/lint.feature
@@ -3,41 +3,35 @@ Feature: Lint all starters
   Scenario: Lint astro-airflow-iris starter
     Given I have prepared a config file
     And I have run a non-interactive kedro new with the starter astro-airflow-iris
-    And I have installed the Kedro project's dependencies
     When I lint the project
     Then I should get a successful exit code
 
   Scenario: Lint databricks-iris starter
     Given I have prepared a config file
     And I have run a non-interactive kedro new with the starter databricks-iris
-    And I have installed the Kedro project's dependencies
     When I lint the project
     Then I should get a successful exit code
 
   Scenario: Lint spaceflights-pandas starter
     Given I have prepared a config file
     And I have run a non-interactive kedro new with the starter spaceflights-pandas
-    And I have installed the Kedro project's dependencies
     When I lint the project
     Then I should get a successful exit code
 
   Scenario: Lint spaceflights-pandas-viz starter
     Given I have prepared a config file
     And I have run a non-interactive kedro new with the starter spaceflights-pandas-viz
-    And I have installed the Kedro project's dependencies
     When I lint the project
     Then I should get a successful exit code
 
   Scenario: Lint spaceflights-pyspark starter
     Given I have prepared a config file
     And I have run a non-interactive kedro new with the starter spaceflights-pyspark
-    And I have installed the Kedro project's dependencies
     When I lint the project
     Then I should get a successful exit code
 
   Scenario: Lint spaceflights-pyspark-viz starter
     Given I have prepared a config file
     And I have run a non-interactive kedro new with the starter spaceflights-pyspark-viz
-    And I have installed the Kedro project's dependencies
     When I lint the project
     Then I should get a successful exit code


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->
1. Lint doesn't require project requirements anymore since we moved to ruff and not using `kedro lint`
2. Pin pip <=23.2, see  https://github.com/kedro-org/kedro/blame/b11666e33fce76e724d15922a786a6ce9fd4e791/features/environment.py#L107

Noted pip version is set twice. Previously pip version are sometimes in 23.3 or 21 depending on the OS/tests combo.
1. During e2e test, a new virtualenv is created, so pip is pin.
2. during e2e test before installing the test requirements, pip is also fix.
## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

