### PR TITLE
Fix check for preventing tools-related modifications on starter

### DIFF
--- a/spaceflights-pandas/hooks/post_gen_project.py
+++ b/spaceflights-pandas/hooks/post_gen_project.py
@@ -7,12 +7,12 @@ from kedro.templates.project.hooks.utils import (
 )
 
 
-def main(selected_tools):
+def main(example_pipeline):
     current_dir = Path.cwd()
     requirements_file_path = current_dir / "requirements.txt"
     pyproject_file_path = current_dir / "pyproject.toml"
     python_package_name = '{{ cookiecutter.python_package }}'
-    example_pipeline = "{{ cookiecutter.example_pipeline }}"
+    selected_tools = "{{ cookiecutter.tools }}"
 
     # Handle template directories and requirements according to selected tools
     setup_template_tools(selected_tools, requirements_file_path, pyproject_file_path, python_package_name, example_pipeline)
@@ -23,9 +23,9 @@ def main(selected_tools):
 
 if __name__ == "__main__":
     # Get the selected tools from cookiecutter
-    selected_tools = "{{ cookiecutter.tools }}"
+    example_pipeline = "{{ cookiecutter.example_pipeline }}"
 
-    # Execute the script only if the tool is selected.
-    # This ensures the script doesn't run with kedro new --starter but only with the tools flow option.
-    if selected_tools != "['None']":
-        main(selected_tools)
+    # Ensure the script doesn't run with kedro new --starter but only with examples selected.
+    # User cannot specify both starter and example.
+    if example_pipeline == "True":
+        main(example_pipeline)


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->
When a starter is selected, any removal of tools should not be applied to the template project. To prevent this, the post project generation hook would check that tools have been specified to gauge if this was a starter selection or example pipeline selection (where the latter would continue with the removal process). 

However, this overlooked the case of no tools selected and an example pipeline being requested - the resulting project _should_ have the unwanted tools stripped of it, but instead the project template was treated like a starter and no modifications were made. This is addressed by testing for an example-pipeline instead of a tools selection - this check is more robust, particularly because example-pipeline **cannot** be true when a starter flag is used.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

