### PR TITLE
Remove tutorial references from generated README files

### DIFF
--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/README.md
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is your new Kedro project for the [spaceflights tutorial](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html) and the extra tutorial sections on [visualisation with Kedro-Viz](https://docs.kedro.org/projects/kedro-viz/en/stable/kedro-viz_visualisation.html) and [experiment tracking with Kedro-Viz](https://docs.kedro.org/projects/kedro-viz/en/stable/experiment_tracking.html), which was generated using `kedro {{ cookiecutter.kedro_version }}`.
+This is your new Kedro project with Kedro-Viz setup, which was generated using `kedro {{ cookiecutter.kedro_version }}`.
 
 Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/README.md
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is your new Kedro project for the [spaceflights tutorial](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html), which was generated using `kedro {{ cookiecutter.kedro_version }}`.
+This is your new Kedro project, which was generated using `kedro {{ cookiecutter.kedro_version }}`.
 
 Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/README.md
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is your new Kedro project for the [spaceflights tutorial](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html) and the extra tutorial sections on [visualisation with Kedro-Viz](https://docs.kedro.org/projects/kedro-viz/en/stable/kedro-viz_visualisation.html) and [experiment tracking with Kedro-Viz](https://docs.kedro.org/projects/kedro-viz/en/stable/experiment_tracking.html) with PySpark setup, which was generated using `kedro {{ cookiecutter.kedro_version }}`.
+This is your new Kedro project with Kedro-Viz and PySpark setup, which was generated using `kedro {{ cookiecutter.kedro_version }}`.
 
 Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/README.md
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is your new Kedro project for the [spaceflights tutorial](https://docs.kedro.org/en/stable/tutorial/spaceflights_tutorial.html) with PySpark setup, which was generated using `kedro {{ cookiecutter.kedro_version }}`.
+This is your new Kedro project with PySpark setup, which was generated using `kedro {{ cookiecutter.kedro_version }}`.
 
 Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->
Context: https://github.com/kedro-org/kedro/issues/3433

READMEs for projects generated with `kedro new` and example code make unnecessary reference to the spaceflights tutorial. This PR removes these references from the README templates, but preserves mention of if Viz and PySpark tools were selected.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

