### PR TITLE
Update all `ConfigLoader` uses to `OmegaconfigLoader`

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/tests/test_run.py
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/tests/test_run.py
@@ -10,14 +10,14 @@ To run the tests, run ``kedro test`` from the project root directory.
 from pathlib import Path
 
 import pytest
-from kedro.config import ConfigLoader
+from kedro.config import OmegaConfigLoader
 from kedro.framework.context import KedroContext
 from kedro.framework.hooks import _create_hook_manager
 
 
 @pytest.fixture
 def config_loader():
-    return ConfigLoader(conf_source=str(Path.cwd()))
+    return OmegaConfigLoader(conf_source=str(Path.cwd()))
 
 
 @pytest.fixture

--- a/databricks-iris/{{ cookiecutter.repo_name }}/tests/test_run.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/tests/test_run.py
@@ -11,14 +11,14 @@ To run the tests, run ``kedro test`` from the project root directory.
 from pathlib import Path
 
 import pytest
-from kedro.config import ConfigLoader
+from kedro.config import OmegaConfigLoader
 from kedro.framework.context import KedroContext
 from kedro.framework.hooks import _create_hook_manager
 
 
 @pytest.fixture
 def config_loader():
-    return ConfigLoader(conf_source=str(Path.cwd()))
+    return OmegaConfigLoader(conf_source=str(Path.cwd()))
 
 
 @pytest.fixture

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/tests/test_run.py
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/tests/test_run.py
@@ -10,14 +10,14 @@ To run the tests, run ``kedro test`` from the project root directory.
 from pathlib import Path
 
 import pytest
-from kedro.config import ConfigLoader
+from kedro.config import OmegaConfigLoader
 from kedro.framework.context import KedroContext
 from kedro.framework.hooks import _create_hook_manager
 
 
 @pytest.fixture
 def config_loader():
-    return ConfigLoader(conf_source=str(Path.cwd()))
+    return OmegaConfigLoader(conf_source=str(Path.cwd()))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation and Context
While creating a demo project I noticed errors for the tests that were still referencing the old `ConfigLoader`.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

