### PR TITLE
Remove `kedro-telemetry` dependency

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -5,7 +5,6 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas-csvdataset]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset]>=1.0; python_version < "3.9"
 kedro-airflow~=0.5
-kedro-telemetry>=0.3.1
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0
 pytest~=7.2

--- a/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -3,7 +3,6 @@ jupyterlab>=3.0
 notebook
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[spark.SparkDataset, pandas.ParquetDataset]>=1.0
-kedro-telemetry>=0.3.1
 numpy~=1.21
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/requirements.txt
@@ -4,7 +4,6 @@ notebook
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, plotly.PlotlyDataset, plotly.JSONDataset, matplotlib.MatplotlibWriter]>=1.0; python_version < "3.9"
-kedro-telemetry>=0.3.1
 kedro-viz>=6.7.0
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
@@ -4,7 +4,6 @@ notebook
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset]>=1.0; python_version < "3.9"
-kedro-telemetry>=0.3.1
 kedro-viz>=6.7.0
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/requirements.txt
@@ -4,7 +4,6 @@ notebook
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, spark.SparkDataset, plotly.PlotlyDataset, plotly.JSONDataset, matplotlib.MatplotlibWriter]>=1.0; python_version < "3.9"
-kedro-telemetry>=0.3.1
 kedro-viz>=6.7.0
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
@@ -4,7 +4,6 @@ notebook
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, spark.SparkDataset]>=1.0; python_version < "3.9"
-kedro-telemetry>=0.3.1
 kedro-viz>=6.7.0
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0


### PR DESCRIPTION
## Motivation and Context
Partly solves https://github.com/kedro-org/kedro-plugins/issues/726

Removed the `kedro-telemetry` dependency from all starters as moving to Kedro core dependencies.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

