### PR TITLE
Bump doc requirements for successful build

### DIFF
--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -14,15 +14,15 @@ dynamic = ["dependencies", "version"]
 
 [project.optional-dependencies]
 docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
+    "docutils<0.21",
+    "sphinx>=5.3,<7.3",
+     "sphinx_rtd_theme==2.0.0",
     "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
+    "sphinx-autodoc-typehints==1.20.2",
+    "sphinx_copybutton==0.5.2",
     "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
+    "Jinja2<3.2.0",
+    "myst-parser>=1.0,<2.1"
 ]
 
 [tool.setuptools.dynamic]

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -14,15 +14,15 @@ dynamic = ["dependencies", "version"]
 
 [project.optional-dependencies]
 docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
+    "docutils<0.21",
+    "sphinx>=5.3,<7.3",
+     "sphinx_rtd_theme==2.0.0",
     "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
+    "sphinx-autodoc-typehints==1.20.2",
+    "sphinx_copybutton==0.5.2",
     "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
+    "Jinja2<3.2.0",
+    "myst-parser>=1.0,<2.1"
 ]
 
 [tool.setuptools.dynamic]

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -14,15 +14,15 @@ dynamic = ["dependencies", "version"]
 
 [project.optional-dependencies]
 docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
+    "docutils<0.21",
+    "sphinx>=5.3,<7.3",
+     "sphinx_rtd_theme==2.0.0",
     "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
+    "sphinx-autodoc-typehints==1.20.2",
+    "sphinx_copybutton==0.5.2",
     "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
+    "Jinja2<3.2.0",
+    "myst-parser>=1.0,<2.1"
 ]
 
 [tool.setuptools.dynamic]

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -14,15 +14,15 @@ dynamic = ["dependencies", "version"]
 
 [project.optional-dependencies]
 docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
+    "docutils<0.21",
+    "sphinx>=5.3,<7.3",
+     "sphinx_rtd_theme==2.0.0",
     "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
+    "sphinx-autodoc-typehints==1.20.2",
+    "sphinx_copybutton==0.5.2",
     "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
+    "Jinja2<3.2.0",
+    "myst-parser>=1.0,<2.1"
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Description
Fix https://github.com/kedro-org/kedro/issues/3774

## Development notes
Updated doc requirements to make sure docs in a new project can be built successfully. Same fix done on the main repo side: https://github.com/kedro-org/kedro/pull/3998

## How has this been tested?
Manually created kedro projects and followed the steps outlined in https://github.com/kedro-org/kedro/issues/3774 both with and without examples.

```
kedro new #... enable docs, enter the project
pip install -e '.[docs]'
mkdir docs/_build
python -m sphinx docs/source docs/_build
```

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

