### PR TITLE
align databricks-iris template to work with kedro-databricks

### DIFF
--- a/databricks-iris/{{ cookiecutter.repo_name }}/README.md
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/README.md
@@ -6,6 +6,33 @@ This is your new Kedro project, which was generated using `kedro {{ cookiecutter
 
 Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 
+## Getting Started
+
+To create a project based on this starter, ensure you have installed Kedro into a virtual environment. Then use the following command:
+
+```sh
+pip install kedro
+kedro new --starter=databricks-iris
+```
+
+After the project is created, navigate to the newly created project directory:
+
+```sh
+cd <my-project-name>  # change directory 
+```
+
+Install the required dependencies:
+
+```sh
+pip install -r requirements.txt
+```
+
+Now you can run the project:
+
+```sh
+kedro run
+```
+
 ## Rules and guidelines
 
 In order to get the best out of the template:

--- a/databricks-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -44,7 +44,7 @@
 
 example_iris_data:
   type: spark.SparkDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/01_raw/iris.csv
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/01_raw/iris.csv
   file_format: csv
   load_args:
     header: True
@@ -56,48 +56,45 @@ example_iris_data:
 # for all SparkDatasets.
 X_train@pyspark:
   type: spark.SparkDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/X_train.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/X_train.parquet
   save_args:
     mode: overwrite
 
 X_train@pandas:
   type: pandas.ParquetDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/X_train.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/X_train.parquet
 
 X_test@pyspark:
   type: spark.SparkDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/X_test.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/X_test.parquet
   save_args:
     mode: overwrite
 
 X_test@pandas:
   type: pandas.ParquetDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/X_test.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/X_test.parquet
 
 y_train@pyspark:
   type: spark.SparkDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/y_train.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/y_train.parquet
   save_args:
     mode: overwrite
 
 y_train@pandas:
   type: pandas.ParquetDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/y_train.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/y_train.parquet
 
 y_test@pyspark:
   type: spark.SparkDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/y_test.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/y_test.parquet
   save_args:
     mode: overwrite
 
 y_test@pandas:
   type: pandas.ParquetDataset
-  filepath: /dbfs/FileStore/iris-databricks/data/02_intermediate/y_test.parquet
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/y_test.parquet
 
-# This is an example how to use `MemoryDataset` with Spark objects that aren't `DataFrame`'s.
-# In particular, the `assign` copy mode ensures that the `MemoryDataset` will be assigned
-# the Spark object itself, not a deepcopy version of it, since deepcopy doesn't work with
-# Spark object generally.
-example_classifier:
-  type: MemoryDataset
-  copy_mode: assign
+y_pred@pandas:
+  type: pandas.ParquetDataset
+  filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/03_primary/y_pred.parquet
+

--- a/databricks-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -94,7 +94,7 @@ y_test@pandas:
   type: pandas.ParquetDataset
   filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/02_intermediate/y_test.parquet
 
-y_pred@pandas:
+y_pred:
   type: pandas.ParquetDataset
   filepath: /dbfs/FileStore/{{ cookiecutter.python_package }}/data/03_primary/y_pred.parquet
 

--- a/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -2,7 +2,7 @@ ipython>=8.10
 jupyterlab>=3.0
 notebook
 kedro~={{ cookiecutter.kedro_version }}
-kedro-datasets[spark.SparkDataset, pandas.ParquetDataset]>=1.0
+kedro-datasets[spark, pandas, spark.SparkDataset, pandas.ParquetDataset]>=1.0
 kedro-telemetry>=0.3.1
 numpy~=1.21
 pytest-cov~=3.0

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/databricks_run.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/databricks_run.py
@@ -24,7 +24,7 @@ def main():
 
     configure_project(package_name)
     with KedroSession.create(env=env, conf_source=conf_source) as session:
-        if len(nodes) == 0:
+        if not nodes:
             session.run()
         else:
             session.run(node_names=nodes)

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/databricks_run.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/databricks_run.py
@@ -10,11 +10,13 @@ def main():
     parser.add_argument("--env", dest="env", type=str)
     parser.add_argument("--conf-source", dest="conf_source", type=str)
     parser.add_argument("--package-name", dest="package_name", type=str)
+    parser.add_argument("--nodes", dest="nodes", type=str)
 
     args = parser.parse_args()
     env = args.env
     conf_source = args.conf_source
     package_name = args.package_name
+    nodes = [node.strip() for node in args.nodes.split(",")]
 
     # https://kb.databricks.com/notebooks/cmd-c-on-object-id-p0.html
     logging.getLogger("py4j.java_gateway").setLevel(logging.ERROR)
@@ -22,7 +24,10 @@ def main():
 
     configure_project(package_name)
     with KedroSession.create(env=env, conf_source=conf_source) as session:
-        session.run()
+        if len(nodes) == 0:
+            session.run()
+        else:
+            session.run(node_names=nodes)
 
 
 if __name__ == "__main__":

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline.py
@@ -25,12 +25,12 @@ def create_pipeline(**kwargs) -> Pipeline:
             node(
                 func=make_predictions,
                 inputs=["X_train@pandas", "X_test@pandas", "y_train@pandas"],
-                outputs="y_pred",
+                outputs="y_pred@pandas",
                 name="make_predictions",
             ),
             node(
                 func=report_accuracy,
-                inputs=["y_pred", "y_test@pandas"],
+                inputs=["y_pred@pandas", "y_test@pandas"],
                 outputs=None,
                 name="report_accuracy",
             ),

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline.py
@@ -25,12 +25,12 @@ def create_pipeline(**kwargs) -> Pipeline:
             node(
                 func=make_predictions,
                 inputs=["X_train@pandas", "X_test@pandas", "y_train@pandas"],
-                outputs="y_pred@pandas",
+                outputs="y_pred",
                 name="make_predictions",
             ),
             node(
                 func=report_accuracy,
-                inputs=["y_pred@pandas", "y_test@pandas"],
+                inputs=["y_pred", "y_test@pandas"],
                 outputs=None,
                 name="report_accuracy",
             ),


### PR DESCRIPTION
## Motivation and Context
This PR is made to align the `databricks-iris` starter to the `kedro-databricks` plugin. 

With these changes, creating a new Kedro project on Databricks should be as easy as:

- Create a project `kedro new --starter="databricks-iris"`
- Install dependencies `python -m venv .venv && source ./.venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt`
- Initialize databricks asset bundle `kedro databricks init`
- Bundle pipelines to asset bundle resources `kedro databricks bundle`
- Deploy project to Databricks `kedro databricks deploy`

## How has this been tested?
The above has been tested against a private Databricks workspace.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

