### PR TITLE
Updated starters to return project run output

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation and Context
Updated starters to return project run output in the interactive environment

Follows https://github.com/kedro-org/kedro/pull/4139

Solves https://github.com/kedro-org/kedro/issues/2681

## How has this been tested?

1. `kedro package`
2. `pip install dist/<package>`
3. `ipython`
4. `import <package>`
5. `from <package>.__main__ import main()`
6. `main()`
7. your project will run and return `session.run()` output

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

