### PR TITLE
Move development requirements

### DIFF
--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,6 +24,12 @@ docs = [
     "Jinja2<3.1.0",
     "myst-parser~=0.17.2",
 ]
+dev = [
+    "pytest-cov~=3.0",
+    "pytest-mock>=1.7.1, <2.0",
+    "pytest~=7.2",
+    "ruff~=0.1.8"
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -6,7 +6,3 @@ kedro[jupyter]
 kedro-datasets[pandas-csvdataset]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset]>=1.0; python_version < "3.9"
 kedro-airflow~=0.5
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.1.8

--- a/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,6 +24,12 @@ docs = [
     "Jinja2<3.1.0",
     "myst-parser~=0.17.2",
 ]
+dev = [
+    "pytest-cov~=3.0",
+    "pytest-mock>=1.7.1, <2.0",
+    "pytest~=7.2",
+    "ruff~=0.1.8"
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}

--- a/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -5,7 +5,3 @@ kedro~={{ cookiecutter.kedro_version }}
 kedro[jupyter]
 kedro-datasets[spark, pandas, spark.SparkDataset, pandas.ParquetDataset]>=1.0
 numpy~=1.21
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.1.8

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,6 +24,12 @@ docs = [
     "Jinja2<3.2.0",
     "myst-parser>=1.0,<2.1"
 ]
+dev = [
+    "pytest-cov~=3.0",
+    "pytest-mock>=1.7.1, <2.0",
+    "pytest~=7.2",
+    "ruff~=0.1.8"
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}

--- a/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas-viz/{{ cookiecutter.repo_name }}/requirements.txt
@@ -6,10 +6,6 @@ kedro[jupyter]
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, plotly.PlotlyDataset, plotly.JSONDataset, matplotlib.MatplotlibWriter]>=1.0; python_version < "3.9"
 kedro-viz>=6.7.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.1.8
 scikit-learn~=1.5.1; python_version >= "3.9"
 scikit-learn<=1.4.0,>=1.0; python_version < "3.9"
 seaborn~=0.12.1

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -16,13 +16,19 @@ dynamic = ["dependencies", "version"]
 docs = [
     "docutils<0.21",
     "sphinx>=5.3,<7.3",
-     "sphinx_rtd_theme==2.0.0",
+    "sphinx_rtd_theme==2.0.0",
     "nbsphinx==0.8.1",
     "sphinx-autodoc-typehints==1.20.2",
     "sphinx_copybutton==0.5.2",
     "ipykernel>=5.3, <7.0",
     "Jinja2<3.2.0",
     "myst-parser>=1.0,<2.1"
+]
+dev = [
+    "pytest-cov~=3.0",
+    "pytest-mock>=1.7.1, <2.0",
+    "pytest~=7.2",
+    "ruff~=0.1.8"
 ]
 
 [tool.setuptools.dynamic]

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
@@ -6,9 +6,5 @@ kedro[jupyter]
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset]>=1.0; python_version < "3.9"
 kedro-viz>=6.7.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.1.8
 scikit-learn~=1.5.1; python_version >= "3.9"
 scikit-learn<=1.4.0,>=1.0; python_version < "3.9"

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,6 +24,12 @@ docs = [
     "Jinja2<3.2.0",
     "myst-parser>=1.0,<2.1"
 ]
+dev = [
+    "pytest-cov~=3.0",
+    "pytest-mock>=1.7.1, <2.0",
+    "pytest~=7.2",
+    "ruff~=0.1.8"
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}

--- a/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark-viz/{{ cookiecutter.repo_name }}/requirements.txt
@@ -6,10 +6,6 @@ kedro[jupyter]
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, spark.SparkDataset, plotly.PlotlyDataset, plotly.JSONDataset, matplotlib.MatplotlibWriter]>=1.0; python_version < "3.9"
 kedro-viz>=6.7.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.1.8
 scikit-learn~=1.5.1; python_version >= "3.9"
 scikit-learn<=1.4.0,>=1.0; python_version < "3.9"
 seaborn~=0.12.1

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,6 +24,12 @@ docs = [
     "Jinja2<3.2.0",
     "myst-parser>=1.0,<2.1"
 ]
+dev = [
+    "pytest-cov~=3.0",
+    "pytest-mock>=1.7.1, <2.0",
+    "pytest~=7.2",
+    "ruff~=0.1.8"
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
@@ -6,9 +6,5 @@ kedro[jupyter]
 kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset]>=3.0; python_version >= "3.9"
 kedro-datasets[pandas.CSVDataset, pandas.ExcelDataset, pandas.ParquetDataset, spark.SparkDataset]>=1.0; python_version < "3.9"
 kedro-viz>=6.7.0
-pytest-cov~=3.0
-pytest-mock>=1.7.1, <2.0
-pytest~=7.2
-ruff~=0.1.8
 scikit-learn~=1.5.1; python_version >= "3.9"
 scikit-learn<=1.4.0,>=1.0; python_version < "3.9"


### PR DESCRIPTION
## Motivation and Context
Solves https://github.com/kedro-org/kedro/issues/2519

For each starter we moved development dependencies from `requirements.txt` to the `[project.optional-dependencies][dev]` section the the `pyproject.toml`

Corresponding docs update: https://github.com/kedro-org/kedro/pull/4178

## How has this been tested?

1. Create a starter
2. In the project root run

- `pip install .` - should install only requirements from `requirements.txt`
- `pip install ."[dev]"` - should install requirements from the `pyproject.toml` (`dev` section in the `[project.optional-dependencies]`)

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

