### PR TITLE
Add wizard GH actions for automation

### DIFF
--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -1,0 +1,48 @@
+name: Label Community Issues
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if issue author is a member of Kedro org
+        uses: actions/github-script@v6
+        id: membership
+        with:
+          github-token: ${{ secrets.GH_TAGGING_TOKEN }}
+          result-encoding: string
+          script: |
+
+            try {
+              const result = await github.rest.orgs.getMembershipForUser({
+                       org: "kedro-org",
+                       username: '${{ github.actor }}'
+                    })
+
+              console.log(result?.data?.state)
+              if (result?.data?.state == "active"){
+                console.log("%s: detected as an active member of Kedro org", '${{ github.actor }}')
+                return "member";
+              } else {
+                console.log("%s: not detected as active member of Kedro org", '${{ github.actor }}')
+                return "notMember";
+              }
+
+            } catch (error) {
+              console.log("%s: Error occured and marked user as notMember", '${{ github.actor }}')
+              console.log("Error", error.stack);
+              console.log("Error", error.name);
+              console.log("Error", error.message);
+              return "notMember";
+            }
+
+      - name: Label issue if author is from community
+        if: ${{ steps.membership.outputs.result == 'notMember' }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GH_TAGGING_TOKEN }}
+          labels: 'Community'

--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/github-script@v6
         id: membership
         with:
-          github-token: ${{ secrets.GH_TAGGING_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
           script: |
 
@@ -44,5 +44,5 @@ jobs:
         if: ${{ steps.membership.outputs.result == 'notMember' }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          github_token: ${{ secrets.GH_TAGGING_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'Community'

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           responseRequiredLabel: "support: needs more info"
           daysUntilClose: 28
           closeComment: >-

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -4,8 +4,8 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Run every day at 9am (UTC time)
+    - cron: '0 9 * * *'
 
 jobs:
   noResponse:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           token: ${{ github.token }}
           responseRequiredLabel: "support: needs more info"
-          daysUntilClose: 14
+          daysUntilClose: 28
           closeComment: >-
             This issue has been closed due to lack of information. Feel free to re-open this issue if you're facing a similar problem. Please provide as much information as possible so we can help resolve your issue.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,20 @@
+name: No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          responseRequiredLabel: "support: needs more info"
+          daysUntilClose: 14
+          closeComment: >-
+            This issue has been closed due to lack of information. Feel free to re-open this issue if you're facing a similar problem. Please provide as much information as possible so we can help resolve your issue.


### PR DESCRIPTION
## Motivation and Context
Mirroring the actions added to `kedro` to automatically add the "Community" label to any issues created by people outside the TSC and monitor tickets labelled with `support: needs more info` to close them automatically if no response after 28 days or to remove the label if the author does respond.


## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

