### PR TITLE
remove test related to viz tool

### DIFF
--- a/features/tools.feature
+++ b/features/tools.feature
@@ -8,7 +8,7 @@ Feature: New Kedro project with tools
     When I run the Kedro pipeline
     Then I should get a successful exit code
 
-  Scenario: Create a new Kedro project with all tools except 'viz' and 'pyspark'
+  Scenario: Create a new Kedro project with all tools except 'pyspark'
     Given I have prepared a config file with tools "lint, test, log, docs, data"
     When I run a non-interactive kedro new without starter
     Then the expected tool directories and files should be created with "lint, test, log, docs, data"
@@ -28,14 +28,6 @@ Feature: New Kedro project with tools
     Given I have prepared a config file with tools "pyspark"
     When I run a non-interactive kedro new without starter
     Then the expected tool directories and files should be created with "pyspark"
-    Given I have installed the Kedro project's dependencies
-    When I run the Kedro pipeline
-    Then I should get a successful exit code
-
-  Scenario: Create a new Kedro project with only 'viz' tool
-    Given I have prepared a config file with tools "viz"
-    When I run a non-interactive kedro new without starter
-    Then the expected tool directories and files should be created with "viz"
     Given I have installed the Kedro project's dependencies
     When I run the Kedro pipeline
     Then I should get a successful exit code


### PR DESCRIPTION
## Motivation and Context
Currently there's a failed test related to the removal of viz tool from framework. This is to remove the test since viz tool has also been removed from framework

https://github.com/kedro-org/kedro-starters/actions/runs/13777466043/job/38544824134

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

