### PR TITLE
Fix databricks-iris `cookiecutter.json`

### DIFF
--- a/databricks-iris/cookiecutter.json
+++ b/databricks-iris/cookiecutter.json
@@ -2,5 +2,7 @@
     "project_name": "Iris",
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
-    "kedro_version": "{{ cookiecutter.kedro_version }}"
+    "kedro_version": "{{ cookiecutter.kedro_version }}",
+    "tools": "{{ cookiecutter.tools }}",
+    "example_pipeline": "{{ cookiecutter.example_pipeline }}"
 }

--- a/databricks-iris/hooks/post_gen_project.py
+++ b/databricks-iris/hooks/post_gen_project.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from kedro.templates.project.hooks.utils import (
+
+    setup_template_tools,
+    sort_requirements,
+)
+
+
+def main(example_pipeline):
+    current_dir = Path.cwd()
+    requirements_file_path = current_dir / "requirements.txt"
+    pyproject_file_path = current_dir / "pyproject.toml"
+    python_package_name = '{{ cookiecutter.python_package }}'
+    selected_tools = "{{ cookiecutter.tools }}"
+
+    # Handle template directories and requirements according to selected tools
+    setup_template_tools(selected_tools, requirements_file_path, pyproject_file_path, python_package_name, example_pipeline)
+
+    # Sort requirements.txt file in alphabetical order
+    sort_requirements(requirements_file_path)
+
+
+if __name__ == "__main__":
+    # Get the selected tools from cookiecutter
+    example_pipeline = "{{ cookiecutter.example_pipeline }}"
+
+    # Ensure the script doesn't run with kedro new --starter but only with examples selected.
+    # User cannot specify both starter and example.
+    if example_pipeline == "True":
+        main(example_pipeline)

--- a/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/iris/__init__.py
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/iris/__init__.py
@@ -1,0 +1,3 @@
+"""Complete iris pipeline for the tutorial"""
+
+from .pipeline import create_pipeline  # NOQA


### PR DESCRIPTION
## Motivation and Context
Fixes: https://kedro-org.slack.com/archives/C03RKPCLYGY/p1742985578637909

The `databricks-iris` starter was breaking when used with the modular pipeline structure. Moving files from a flat structure to a modular one (`pipelines/iris/`) without adding the `tools` and `example_pipeline` variables in `cookiecutter.json` caused the `kedro-databricks` plugin to fail when generating resources with `kedro databricks bundle`.

## Development notes

- Added proper exports in `pipelines/iris/__init__.py`
- Added `tools` and `example_pipeline` variables in `cookiecutter.json` (Main fix)
- Added `post_gen_project.py` for consistency with other starters

## How has this been tested?
<!-- What testing strategies have you used? -->

1. Creating a new project with the updated databricks-iris starter
2. Make sure the proper directory structure was created with the correct imports
3. Running `kedro databricks bundle` and check files in `resources/` was created.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

