### PR TITLE
fix: databricks does not like it when you change their core dependencies

### DIFF
--- a/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -8,13 +8,8 @@ name = "{{ cookiecutter.python_package }}"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "ipython>=8.10",
-    "jupyterlab>=3.0",
-    "notebook",
-    "kedro[jupyter]~={{ cookiecutter.kedro_version }}",
-    "kedro-datasets[spark, pandas, spark.SparkDataset, pandas.ParquetDataset]>=3.0",
-    "numpy~=1.21; python_version <= '3.9'",
-    "numpy~=2.1; python_version > '3.9'"
+    "kedro~={{ cookiecutter.kedro_version }}",
+    "kedro-datasets[spark, spark.SparkDataset]>=3.0",
 ]
 
 [project.scripts]
@@ -38,11 +33,17 @@ dev = [
     "pytest-cov~=3.0",
     "pytest-mock>=1.7.1, <2.0",
     "pytest~=7.2",
-    "ruff~=0.1.8"
+    "ruff~=0.1.8",
+    "kedro[jupyter]~={{ cookiecutter.kedro_version }}",
+    "numpy~=1.21; python_version <= '3.9'",
+    "numpy~=2.1; python_version > '3.9'",
+    "ipython>=8.10",
+    "jupyterlab>=3.0",
+    "notebook",
 ]
 
 [tool.setuptools.dynamic]
-version = {attr = "{{ cookiecutter.python_package }}.__version__"}
+version = { attr = "{{ cookiecutter.python_package }}.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -71,12 +72,12 @@ docstring-code-format = true
 line-length = 88
 show-fixes = true
 select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
+    "F",    # Pyflakes
+    "W",    # pycodestyle
+    "E",    # pycodestyle
+    "I",    # isort
+    "UP",   # pyupgrade
+    "PL",   # Pylint
     "T201", # Print Statement
 ]
-ignore = ["E501"]  # Ruff format takes care of line-too-long
+ignore = ["E501"] # Ruff format takes care of line-too-long


### PR DESCRIPTION
## Motivation and Context

I would argue that all the things that I have moved are actually _dev_ dependencies as they are not required when working within the Databricks platform, only locally.

---

Currently, when using this starter directly on Databricks in a Job, you get the following error. (Note I used Databricks Asset Bundles and `kedro-databricks`)

<img width="1561" alt="image" src="https://github.com/user-attachments/assets/44dd4fbd-4076-4645-9ca4-965f1bb1f1bb" />

Diving into the logs, you can see that what causes it, is the classic numpy error.

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/ba614df7-47cc-47ef-b1a0-bbde90d02d37" />

## How has this been tested?

Moving all the dependencies as shown here results in a working job.

<img width="1553" alt="image" src="https://github.com/user-attachments/assets/d92d0166-98e4-4f58-8883-c9d5b75732da" />

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

