### PR TITLE
Change create_confusion_matrix to output image

### DIFF
--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/reporting/nodes.py
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/reporting/nodes.py
@@ -37,19 +37,19 @@ def compare_passenger_capacity_go(preprocessed_shuttles: pd.DataFrame):
 
 def create_confusion_matrix(companies: pd.DataFrame):
     matplotlib.use('Agg')
-    
+
     actuals = [0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1]
     predicted = [1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1]
     data = {"y_Actual": actuals, "y_Predicted": predicted}
     df = pd.DataFrame(data, columns=["y_Actual", "y_Predicted"])
-    
+
     confusion_matrix = pd.crosstab(
         df["y_Actual"], df["y_Predicted"], rownames=["Actual"], colnames=["Predicted"]
     )
-    
+
     fig, ax = plt.subplots(figsize=(8, 6))
     sn.heatmap(confusion_matrix, annot=True, fmt='d', cmap='Blues', ax=ax)
     ax.set_title('Confusion Matrix')
     plt.tight_layout()
-    
+
     return fig

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/reporting/nodes.py
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipelines/reporting/nodes.py
@@ -59,19 +59,19 @@ def compare_passenger_capacity_go(preprocessed_shuttles: SparkDataFrame):
 
 def create_confusion_matrix(companies: pd.DataFrame):
     matplotlib.use('Agg')
-    
+
     actuals = [0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1]
     predicted = [1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1]
     data = {"y_Actual": actuals, "y_Predicted": predicted}
     df = pd.DataFrame(data, columns=["y_Actual", "y_Predicted"])
-    
+
     confusion_matrix = pd.crosstab(
         df["y_Actual"], df["y_Predicted"], rownames=["Actual"], colnames=["Predicted"]
     )
-    
+
     fig, ax = plt.subplots(figsize=(8, 6))
     sn.heatmap(confusion_matrix, annot=True, fmt='d', cmap='Blues', ax=ax)
     ax.set_title('Confusion Matrix')
     plt.tight_layout()
-    
+
     return fig


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->

https://github.com/kedro-org/kedro/issues/4891

Fixes a hang that happened when running the pipeline with `ThreadRunner`. This happened because the original function was using matplotlib with its default interactive backends, which are not thread safe.

Explicitly setting matplotlib to use the [anti-grain geometry backend](https://matplotlib.org/stable/api/backend_agg_api.html#module-matplotlib.backends.backend_agg) to ensure non-interactive rendering lets the pipeline run normally. Output should be identical.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

