### PR TITLE
Update MatplotlibDataset and remove Python 3.9 support

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest , ubuntu-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest , ubuntu-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/astro-airflow-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/astro-airflow-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 name = "{{ cookiecutter.python_package }}"
 readme = "README.md"
 dynamic = ["version"]

--- a/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 name = "{{ cookiecutter.python_package }}"
 readme = "README.md"
 dynamic = ["version"]
@@ -13,8 +13,7 @@ dependencies = [
     "notebook",
     "kedro[jupyter]~={{ cookiecutter.kedro_version }}",
     "kedro-datasets[spark, pandas, spark.SparkDataset, pandas.ParquetDataset]>=3.0",
-    "numpy~=1.21; python_version <= '3.9'",
-    "numpy~=2.1; python_version > '3.9'"
+    "numpy~=2.1"
 ]
 
 [project.scripts]

--- a/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/databricks-iris/{{ cookiecutter.repo_name }}/requirements.txt
@@ -3,5 +3,4 @@ jupyterlab>=3.0
 notebook
 kedro[jupyter]~={{ cookiecutter.kedro_version }}
 kedro-datasets[spark, pandas, spark-sparkdataset, pandas-parquetdataset]>=3.0
-numpy~=1.21; python_version <= '3.9'
-numpy~=2.1; python_version > '3.9'
+numpy~=2.1

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -91,6 +91,6 @@ shuttle_passenger_capacity_plot_go:
   versioned: true
 
 dummy_confusion_matrix:
-  type: matplotlib.MatplotlibWriter
+  type: matplotlib.MatplotlibDataset
   filepath: data/08_reporting/dummy_confusion_matrix.png
   versioned: true

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 name = "{{ cookiecutter.python_package }}"
 readme = "README.md"
 dynamic = ["version"]
@@ -12,7 +12,7 @@ dependencies = [
     "jupyterlab>=3.0",
     "notebook",
     "kedro[jupyter]~={{ cookiecutter.kedro_version }}",
-    "kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0",
+    "kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibdataset]>=3.0",
     "kedro-viz>=6.7.0",
     "scikit-learn~=1.5.1",
     "seaborn~=0.12.1"

--- a/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pandas/{{ cookiecutter.repo_name }}/requirements.txt
@@ -2,7 +2,7 @@ ipython>=8.10
 jupyterlab>=3.0
 notebook
 kedro[jupyter]~={{ cookiecutter.kedro_version }}
-kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0
+kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibdataset]>=3.0
 kedro-viz>=6.7.0
 scikit-learn~=1.5.1
 seaborn~=0.12.1

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/conf/base/catalog.yml
@@ -161,6 +161,6 @@ shuttle_passenger_capacity_plot_go:
   versioned: true
 
 dummy_confusion_matrix:
-  type: matplotlib.MatplotlibWriter
+  type: matplotlib.MatplotlibDataset
   filepath: data/08_reporting/dummy_confusion_matrix.png
   versioned: true

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 name = "{{ cookiecutter.python_package }}"
 readme = "README.md"
 dynamic = ["version"]
@@ -12,7 +12,7 @@ dependencies = [
     "jupyterlab>=3.0",
     "notebook",
     "kedro[jupyter]~={{ cookiecutter.kedro_version }}",
-    "kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0",
+    "kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibdataset]>=3.0",
     "kedro-viz>=6.7.0",
     "scikit-learn~=1.5.1",
     "seaborn~=0.12.1",

--- a/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/spaceflights-pyspark/{{ cookiecutter.repo_name }}/requirements.txt
@@ -2,7 +2,7 @@ ipython>=8.10
 jupyterlab>=3.0
 notebook
 kedro[jupyter]~={{ cookiecutter.kedro_version }}
-kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibwriter]>=3.0
+kedro-datasets[pandas-csvdataset, pandas-exceldataset, pandas-parquetdataset, spark-sparkdataset, plotly-plotlydataset, plotly-jsondataset, matplotlib-matplotlibdataset]>=3.0
 kedro-viz>=6.7.0
 scikit-learn~=1.5.1
 seaborn~=0.12.1


### PR DESCRIPTION
## Motivation and Context
<!-- Why was this PR created? -->

https://github.com/kedro-org/kedro/issues/4966

Changes all `MatplotlibWriter` calls to `MatplotlibDataset` as the former is being removed (https://github.com/kedro-org/kedro-plugins/pull/1214).
Updates requirements for all tests and starters to remove support to Python 3.9 in compliance with the October/2025 end-of-life date for this version.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

