### PR TITLE
ci: Add explicit permissions block to GitHub Actions workflows

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   security-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - name: Check if issue author is a member of Kedro org
         uses: actions/github-script@v6

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,6 +4,9 @@ on:
     # Run every day at midnight (UTC time)
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   starters-test:
     uses: ./.github/workflows/all-checks.yml

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   noResponse:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Fixes https://github.com/kedro-org/kedro-starters/issues/295

This PR addresses the CodeQL security vulnerabilities by adding explicit permissions to GitHub Actions workflows. 

## Summary Table

| Workflow | Permissions Added | Purpose |
|----------|-------------------|---------|
| [label-community-issues.yml](.github/workflows/label-community-issues.yml) | `issues: write`, `contents: read` | Checks org membership and labels community issues |
| [all-checks.yml](.github/workflows/all-checks.yml) | `contents: read` | Runs security scan, tests, lint, and package checks |
| [no-response.yml](.github/workflows/no-response.yml) | `issues: write` | Closes stale issues without response |
| [release.yml](.github/workflows/release.yml) | `contents: write` | Creates GitHub releases when triggered |
| [nightly-build.yml](.github/workflows/nightly-build.yml) | `contents: read` | Runs daily tests and notifies on failures |
