### PR TITLE
Fix spark starter test

### DIFF
--- a/features/steps/run_steps.py
+++ b/features/steps/run_steps.py
@@ -117,9 +117,6 @@ def check_created_project_structure_from_tools(context, tools):
     if "data" in tools_list:  # data tool
         assert is_created("data"), "data directory does not exist"
 
-    if "pyspark" in tools_list:  # PySpark tool
-        assert is_created("conf/base/spark.yml"), "spark.yml does not exist"
-
 
 @given("I have installed the Kedro project's dependencies")
 def install_project_dependencies(context):


### PR DESCRIPTION
## Motivation and Context
Fix https://github.com/kedro-org/kedro-starters/issues/310

After we've changed the way Spark is installed for starters (https://github.com/kedro-org/kedro-starters/pull/303) `conf/base/spark.yml` does not exist no more.

## How has this been tested?
<!-- What testing strategies have you used? -->

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

